### PR TITLE
feat: improve admin import experience

### DIFF
--- a/backend/src/routes/imports.ts
+++ b/backend/src/routes/imports.ts
@@ -1,39 +1,138 @@
-﻿import { Router } from "express";
+import { Router } from "express";
 import multer from "multer";
-import { parseCsv } from "../utils/csv.js";
 import { PrismaClient } from "@prisma/client";
+
 import { requireRole } from "../middleware/auth.js";
+import { parseCsv } from "../utils/csv.js";
+
 const prisma = new PrismaClient();
 const router = Router();
 const upload = multer();
 
-router.post("/participantes", requireRole("ADMIN"), upload.single("file"), async (req, res) => {
-  if(!req.file) return res.status(400).json({ error: "Archivo requerido" });
-  const rows = await parseCsv(req.file.buffer);
-  let created = 0, updated = 0, errors: string[] = [];
+const TEMPLATE_CONTENT = `<!DOCTYPE html>
+<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">
+<head>
+<meta charset="UTF-8" />
+<!--[if gte mso 9]><xml>
+ <x:ExcelWorkbook>
+  <x:ExcelWorksheets>
+   <x:ExcelWorksheet>
+    <x:Name>Plantilla</x:Name>
+    <x:WorksheetOptions>
+     <x:DisplayGridlines/>
+    </x:WorksheetOptions>
+   </x:ExcelWorksheet>
+  </x:ExcelWorksheets>
+ </x:ExcelWorkbook>
+</xml><![endif]-->
+<style>
+table { border-collapse: collapse; }
+td, th { border: 1px solid #999; padding: 4px; }
+th { background: #f0f0f0; }
+</style>
+</head>
+<body>
+<table>
+ <thead>
+  <tr>
+   <th>email</th>
+   <th>nombre</th>
+   <th>apellido</th>
+   <th>documento</th>
+   <th>proveedor</th>
+   <th>codigo_curso</th>
+   <th>rol_en_curso</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>participante@org.test</td>
+   <td>Ana</td>
+   <td>Pérez</td>
+   <td>12345678</td>
+   <td>Proveedor Demo</td>
+   <td>CUR-001</td>
+   <td>Alumno</td>
+  </tr>
+ </tbody>
+</table>
+</body>
+</html>`;
 
-  for(const [idx, r] of rows.entries()){
-    try{
-      const provider = await prisma.provider.upsert({ where: { name: r.proveedor }, update: {}, create: { name: r.proveedor } });
-      const course = await prisma.course.findUnique({ where: { code: r.codigo_curso } });
-      if(!course) throw new Error(`Curso ${r.codigo_curso} no existe`);
-      const participant = await prisma.participant.upsert({
-        where: { email: r.email },
-        update: { name: r.nombre, providerId: provider.id },
-        create: { email: r.email, name: r.nombre, providerId: provider.id }
-      });
-      const before = await prisma.enrollment.findUnique({ where: { participantId_courseId: { participantId: participant.id, courseId: course.id } } });
-      if(before){ updated++; }
-      await prisma.enrollment.upsert({
-        where: { participantId_courseId: { participantId: participant.id, courseId: course.id } },
+router.post("/participantes", requireRole("ADMIN"), upload.single("file"), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: "Archivo requerido" });
+  }
+
+  const rows = await parseCsv(req.file.buffer);
+  let created = 0;
+  let updated = 0;
+  const errors: string[] = [];
+
+  for (const [idx, row] of rows.entries()) {
+    try {
+      const provider = await prisma.provider.upsert({
+        where: { name: row.proveedor },
         update: {},
-        create: { participantId: participant.id, courseId: course.id }
+        create: { name: row.proveedor },
       });
-      if(!before) created++;
-    }catch(e:any){
-      errors.push(`Fila ${idx+1}: ${e.message}`);
+
+      const course = await prisma.course.findUnique({
+        where: { code: row.codigo_curso },
+      });
+
+      if (!course) {
+        throw new Error(`Curso ${row.codigo_curso} no existe`);
+      }
+
+      const participant = await prisma.participant.upsert({
+        where: { email: row.email },
+        update: { name: row.nombre, providerId: provider.id },
+        create: { email: row.email, name: row.nombre, providerId: provider.id },
+      });
+
+      const before = await prisma.enrollment.findUnique({
+        where: {
+          participantId_courseId: {
+            participantId: participant.id,
+            courseId: course.id,
+          },
+        },
+      });
+
+      if (before) {
+        updated += 1;
+      }
+
+      await prisma.enrollment.upsert({
+        where: {
+          participantId_courseId: {
+            participantId: participant.id,
+            courseId: course.id,
+          },
+        },
+        update: {},
+        create: { participantId: participant.id, courseId: course.id },
+      });
+
+      if (!before) {
+        created += 1;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Error desconocido";
+      errors.push(`Fila ${idx + 1}: ${message}`);
     }
   }
+
   res.json({ created, updated, errors, total: rows.length });
 });
+
+router.get("/participantes/plantilla", requireRole("ADMIN"), (_req, res) => {
+  const buffer = Buffer.from(TEMPLATE_CONTENT, "utf8");
+  res.setHeader("Content-Type", "application/vnd.ms-excel");
+  res.setHeader("Content-Disposition", "attachment; filename=plantilla_regasis.xls");
+  res.setHeader("Content-Length", buffer.length.toString());
+  res.send(buffer);
+});
+
 export default router;

--- a/frontend/src/pages/AdminImportaciones.tsx
+++ b/frontend/src/pages/AdminImportaciones.tsx
@@ -1,44 +1,205 @@
-import { FileDown, Upload } from "lucide-react";
+import { useCallback, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { AlertCircle, CheckCircle2, FileDown, Loader2, Upload } from "lucide-react";
 
 import { Button, Card } from "../components/ui";
+import {
+  descargarPlantillaParticipantes,
+  importarParticipantes,
+  type ImportSummary,
+} from "../services/importaciones";
+
+type ImportStatus = "idle" | "uploading" | "downloading";
 
 export default function AdminImportaciones() {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<ImportStatus>("idle");
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+  const [lastRun, setLastRun] = useState<Date | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const importing = status === "uploading";
+  const downloading = status === "downloading";
+
+  const selectFile = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const [file] = event.target.files ?? [];
+    setSelectedFile(file ?? null);
+    setErrorMessage(null);
+  }, []);
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedFile) {
+      setErrorMessage("Selecciona un archivo CSV antes de importar");
+      return;
+    }
+
+    setStatus("uploading");
+    setErrorMessage(null);
+
+    try {
+      const result = await importarParticipantes(selectedFile);
+      setSummary(result);
+      setLastRun(new Date());
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      setSelectedFile(null);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "No se pudo completar la importación. Inténtalo nuevamente.";
+      setErrorMessage(message);
+    } finally {
+      setStatus("idle");
+    }
+  }, [selectedFile]);
+
+  const handleDownload = useCallback(async () => {
+    setStatus("downloading");
+    setErrorMessage(null);
+
+    try {
+      const blob = await descargarPlantillaParticipantes();
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = "plantilla_regasis.xls";
+      document.body.append(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "No se pudo descargar la plantilla. Inténtalo nuevamente.";
+      setErrorMessage(message);
+    } finally {
+      setStatus("idle");
+    }
+  }, []);
+
+  const hasErrors = (summary?.errors.length ?? 0) > 0;
+
+  const metrics = useMemo(
+    () => [
+      { label: "Registros procesados", value: summary?.total ?? 0 },
+      { label: "Creados", value: summary?.created ?? 0 },
+      { label: "Actualizados", value: summary?.updated ?? 0 },
+      { label: "Errores", value: summary?.errors.length ?? 0 },
+    ],
+    [summary],
+  );
+
   return (
     <section className="space-y-4">
-      <header className="flex items-center justify-between">
+      <header className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-xl font-semibold">Importaciones</h1>
-        <div className="flex items-center gap-2">
-          <Button>
-            <Upload size={16} /> Importar CSV participantes
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="button" onClick={handleUpload} disabled={importing || downloading}>
+            {importing ? <Loader2 className="mr-2 animate-spin" size={16} /> : <Upload size={16} />}
+            Importar CSV participantes
           </Button>
-          <Button variant="accent">
-            <FileDown size={16} /> Plantilla CSV
+          <Button
+            type="button"
+            variant="accent"
+            onClick={handleDownload}
+            disabled={importing || downloading}
+          >
+            {downloading ? (
+              <Loader2 className="mr-2 animate-spin" size={16} />
+            ) : (
+              <FileDown size={16} />
+            )}
+            Plantilla Excel 97
           </Button>
         </div>
       </header>
       <div className="grid grid-cols-12 gap-4">
         <div className="col-span-12 space-y-4 lg:col-span-8">
-          <Card className="p-4">
-            <p className="label">Subir archivo</p>
-            <input type="file" className="input" accept=".csv" />
-            <p className="mt-2 text-xs text-gray-500">
-              Formato: <code className="font-mono">email,nombre,apellido,documento,proveedor,codigo_curso,rol_en_curso</code>
-            </p>
+          <Card className="space-y-4 p-4">
+            <div>
+              <p className="label">Archivo de participantes</p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                className="input"
+                accept=".csv,text/csv"
+                onChange={selectFile}
+              />
+              <p className="mt-2 text-xs text-gray-500">
+                Formato requerido:
+                <code className="ml-1 font-mono">
+                  email,nombre,apellido,documento,proveedor,codigo_curso,rol_en_curso
+                </code>
+              </p>
+              {selectedFile ? (
+                <p className="mt-2 text-xs text-gray-600">Archivo seleccionado: {selectedFile.name}</p>
+              ) : null}
+            </div>
+            {errorMessage ? (
+              <div className="flex items-start gap-2 rounded-md bg-red-50 p-3 text-sm text-red-700">
+                <AlertCircle size={18} className="mt-0.5" />
+                <div>{errorMessage}</div>
+              </div>
+            ) : null}
+            {lastRun ? (
+              <p className="text-xs text-gray-500">
+                Última ejecución: {lastRun.toLocaleString()}
+              </p>
+            ) : null}
           </Card>
           <Card className="p-4">
-            <p className="text-sm font-semibold">Resumen de resultados</p>
-            <ul className="mt-2 grid grid-cols-2 gap-2 text-sm text-gray-600 md:grid-cols-4">
-              <li className="chip">Creados: 12</li>
-              <li className="chip">Actualizados: 3</li>
-              <li className="chip">Errores: 1</li>
-              <li className="chip">Tiempo: 1.2s</li>
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              {hasErrors ? (
+                <AlertCircle className="text-amber-500" size={18} />
+              ) : summary ? (
+                <CheckCircle2 className="text-emerald-500" size={18} />
+              ) : null}
+              <span>Resumen de resultados</span>
+            </div>
+            <ul className="mt-3 grid grid-cols-2 gap-2 text-sm text-gray-600 md:grid-cols-4">
+              {metrics.map((metric) => (
+                <li key={metric.label} className="chip">
+                  {metric.label}: {metric.value}
+                </li>
+              ))}
             </ul>
+            {hasErrors ? (
+              <div className="mt-4 space-y-2 text-sm text-red-700">
+                <p className="font-medium">Detalle de errores</p>
+                <ul className="space-y-1">
+                  {summary?.errors.map((item) => (
+                    <li key={item} className="rounded bg-red-50 px-3 py-2">
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {!summary ? (
+              <p className="mt-4 text-xs text-gray-500">
+                Ejecuta una importación para ver resultados y métricas en esta sección.
+              </p>
+            ) : null}
           </Card>
         </div>
         <div className="col-span-12 space-y-4 lg:col-span-4">
           <Card className="p-4">
+            <div className="text-sm font-semibold">Buenas prácticas</div>
+            <ul className="mt-2 space-y-1 text-sm text-gray-600">
+              <li>Valida duplicados en el CSV antes de subirlo.</li>
+              <li>Utiliza la plantilla oficial para mantener los encabezados.</li>
+              <li>Verifica los códigos de curso activos.</li>
+            </ul>
+          </Card>
+          <Card className="p-4">
             <div className="text-sm font-semibold">Seguridad</div>
-            <p className="mt-1 text-sm text-gray-600">JWT/OAuth2, HTTPS, contraseñas robustas.</p>
+            <p className="mt-1 text-sm text-gray-600">
+              Las importaciones requieren un usuario con rol Administrador y quedan registradas en la
+              auditoría del sistema.
+            </p>
           </Card>
         </div>
       </div>

--- a/frontend/src/pages/Perfil.tsx
+++ b/frontend/src/pages/Perfil.tsx
@@ -1,8 +1,28 @@
+import { useMemo } from "react";
+
 import { Card, Input, Label } from "../components/ui";
 import { useAuth } from "../hooks/AuthProvider";
+import { APP_ROUTES, type Role } from "../routes/definitions";
+
+const ROLE_LABEL: Record<Role, string> = {
+  ADMIN: "Administrador",
+  INSTRUCTOR: "Instructor",
+  REPORTER: "Reportero",
+};
 
 export default function Perfil() {
   const { user } = useAuth();
+  const role = (user?.role ?? "ADMIN") as Role;
+
+  const allowedRoutes = useMemo(
+    () =>
+      APP_ROUTES.filter((route) => route.roles.includes(role) && route.label).map((route) => ({
+        path: route.path,
+        label: route.label!,
+      })),
+    [role],
+  );
+
   return (
     <section className="space-y-4">
       <h1 className="text-xl font-semibold">Mi Perfil</h1>
@@ -18,13 +38,27 @@ export default function Perfil() {
           </div>
           <div>
             <Label htmlFor="profile-role">Rol</Label>
-            <Input id="profile-role" defaultValue={user?.role || ""} readOnly />
+            <Input id="profile-role" defaultValue={ROLE_LABEL[role]} readOnly />
           </div>
           <div>
             <Label htmlFor="profile-provider">Proveedor</Label>
             <Input id="profile-provider" defaultValue={user?.providerId || ""} readOnly />
           </div>
         </div>
+      </Card>
+      <Card className="p-4">
+        <div className="text-sm font-semibold">Vistas disponibles para tu rol</div>
+        <ul className="mt-3 space-y-2 text-sm text-gray-700">
+          {allowedRoutes.map((route) => (
+            <li key={route.path} className="flex items-center gap-2">
+              <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden />
+              <span>{route.label}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-3 text-xs text-gray-500">
+          Si necesitas permisos adicionales ponte en contacto con el equipo de soporte.
+        </p>
       </Card>
     </section>
   );

--- a/frontend/src/services/importaciones.ts
+++ b/frontend/src/services/importaciones.ts
@@ -1,0 +1,27 @@
+import api from "./http";
+
+export type ImportSummary = {
+  created: number;
+  updated: number;
+  errors: string[];
+  total: number;
+};
+
+export async function importarParticipantes(file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const { data } = await api.post<ImportSummary>("/importaciones/participantes", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+
+  return data;
+}
+
+export async function descargarPlantillaParticipantes() {
+  const response = await api.get<Blob>("/importaciones/participantes/plantilla", {
+    responseType: "blob",
+  });
+
+  return response.data;
+}


### PR DESCRIPTION
## Summary
- generate an Excel 97 compatible participants template and expose it through the imports API
- add a real CSV upload workflow with error handling and metrics on the admin importaciones view
- surface admin role information and accessible views inside the profile page to clarify privileges

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68de07deae748324a4595972476eb28b