### PR TITLE
Fix CSV import utility export and template generation

### DIFF
--- a/backend/src/routes/imports.ts
+++ b/backend/src/routes/imports.ts
@@ -34,7 +34,10 @@ const TEMPLATE_COLUMN_WIDTHS = [28, 18, 18, 14, 22, 16, 16];
 
 function createTemplateWorkbook(): Buffer {
   const workbook = utils.book_new();
-  const sheet = utils.aoa_to_sheet([TEMPLATE_HEADER, TEMPLATE_SAMPLE_ROW]);
+  const sheet = utils.aoa_to_sheet([
+    [...TEMPLATE_HEADER],
+    [...TEMPLATE_SAMPLE_ROW]
+  ]);
 
   // set column widths
   sheet["!cols"] = TEMPLATE_COLUMN_WIDTHS.map((width) => ({ wch: width }));
@@ -59,7 +62,7 @@ const TEMPLATE_BUFFER = createTemplateWorkbook();
 router.post("/participantes", requireRole("ADMIN"), upload.single("file"), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: "Archivo requerido" });
 
-  const rows = await parseCsv(req.file.buffer);
+  const rows = await parseCsv(req.file.buffer, req.file.mimetype);
   let created = 0;
   let updated = 0;
   const errors: string[] = [];

--- a/backend/src/utils/csv.ts
+++ b/backend/src/utils/csv.ts
@@ -113,3 +113,10 @@ export async function parseImportFile(
   }
   return parseCsvBuffer(buffer);
 }
+
+export async function parseCsv(
+  buffer: Buffer,
+  mimetype?: string
+): Promise<Record<string, string>[]> {
+  return parseImportFile(buffer, mimetype);
+}


### PR DESCRIPTION
## Summary
- export a `parseCsv` helper that delegates to the existing import parser
- pass the uploaded file mimetype when parsing participant imports
- coerce the template header/sample rows to mutable arrays before creating the sheet

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7cb386b48324ba5d36afb3ff0d80