### PR TITLE
Allow admins to view their own sessions

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -9,7 +9,7 @@ const router = Router();
 
 router.get(
   "/mias",
-  requireRole("INSTRUCTOR"),
+  requireRole("INSTRUCTOR", "ADMIN"),
   async (req: Request, res: Response, next: NextFunction) => {
     const user = req.user!;
     const userId = user.id;


### PR DESCRIPTION
## Summary
- permit both instructors and admins to access the `/sesiones/mias` endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de98a49b048324823aada8b173b00c