### PR TITLE
Add course picker for new instructor sessions

### DIFF
--- a/backend/src/routes/courses.ts
+++ b/backend/src/routes/courses.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response, type NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { requireRole } from "../middleware/auth.js";
 import {
   listDemoCourses,
@@ -54,6 +54,15 @@ router.post(
       });
       return res.status(201).json(course);
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === "P2003") {
+          return res.status(400).json({ error: "Proveedor inválido. Selecciona un proveedor existente." });
+        }
+        if (error.code === "P2002") {
+          return res.status(400).json({ error: "El código del curso ya está registrado." });
+        }
+      }
+
       if (!isPrismaUnavailable(error)) return next(error);
 
       try {

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -7,11 +7,13 @@ import gradesRouter from "./grades.js";
 import reportsRouter from "./reports.js";
 import importsRouter from "./imports.js";
 import auditRouter from "./audit.js";
+import providersRouter from "./providers.js";
 import { auth } from "../middleware/auth.js";
 
 const router = Router();
 router.use("/auth", auth(false), authRouter);
 router.use("/cursos", auth(), coursesRouter);
+router.use("/proveedores", auth(), providersRouter);
 router.use("/sesiones", auth(), sessionsRouter);
 router.use("/asistencias", auth(), attendanceRouter);
 router.use("/notas", auth(), gradesRouter);

--- a/backend/src/routes/providers.ts
+++ b/backend/src/routes/providers.ts
@@ -1,0 +1,27 @@
+import { Router, type Request, type Response, type NextFunction } from "express";
+import { PrismaClient } from "@prisma/client";
+
+import { requireRole } from "../middleware/auth.js";
+import { isPrismaUnavailable } from "../utils/prisma.js";
+import { listDemoProviders } from "../services/demo-data.js";
+
+const prisma = new PrismaClient();
+const router = Router();
+
+router.get(
+  "/",
+  requireRole("ADMIN"),
+  async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const providers = await prisma.provider.findMany({
+        orderBy: { name: "asc" }
+      });
+      return res.json(providers);
+    } catch (error) {
+      if (!isPrismaUnavailable(error)) return next(error);
+      return res.json(listDemoProviders());
+    }
+  }
+);
+
+export default router;

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -9,7 +9,7 @@ const router = Router();
 
 router.get(
   "/mias",
-  requireRole("INSTRUCTOR"),
+  requireRole("INSTRUCTOR", "ADMIN"),
   async (req: Request, res: Response, next: NextFunction) => {
     const user = req.user!;
     const userId = user.id;

--- a/backend/src/services/demo-data.ts
+++ b/backend/src/services/demo-data.ts
@@ -46,6 +46,16 @@ const provider = {
   updatedAt: new Date("2025-01-01").toISOString()
 };
 
+export function listDemoProviders() {
+  return [
+    {
+      ...provider,
+      createdAt: new Date(provider.createdAt),
+      updatedAt: new Date(provider.updatedAt)
+    }
+  ];
+}
+
 const users: DemoUser[] = [
   {
     id: "demo-admin",

--- a/frontend/src/pages/AdminCursos.tsx
+++ b/frontend/src/pages/AdminCursos.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useMemo, useState } from "react";
-import { Settings } from "lucide-react";
+/* global HTMLFormElement, HTMLInputElement, HTMLSelectElement */
 
-import { Button, Card, Input, Table } from "../components/ui";
-import { listarCursos } from "../services/cursos";
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
+import { Loader2, Plus, Settings, X } from "lucide-react";
+
+import { Button, Card, Input, Label, Table } from "../components/ui";
+import { getCurrentUser } from "../services/auth";
+import { crearCurso, listarCursos, type CursoDTO } from "../services/cursos";
+import { listarProveedores, type ProveedorDTO } from "../services/proveedores";
 
 type CursoItem = {
   id: string;
@@ -13,10 +17,60 @@ type CursoItem = {
   instructores: string[];
 };
 
+type CursoFormState = {
+  code: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  providerId: string;
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString();
+}
+
+function mapCurso(curso: CursoDTO): CursoItem {
+  const instructorNames = (curso.instructors ?? [])
+    .map((instructor) => instructor.user?.name ?? "")
+    .filter((name): name is string => Boolean(name));
+
+  return {
+    id: curso.id,
+    codigo: curso.code,
+    nombre: curso.name,
+    proveedor: curso.provider?.name ?? "—",
+    fechas: `${formatDate(curso.startDate)} – ${formatDate(curso.endDate)}`,
+    instructores: instructorNames,
+  };
+}
+
 export default function AdminCursos() {
   const [query, setQuery] = useState("");
   const [items, setItems] = useState<CursoItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const userProviderId = useMemo(() => getCurrentUser()?.providerId ?? "", []);
+  const [providers, setProviders] = useState<ProveedorDTO[]>([]);
+  const [providersLoading, setProvidersLoading] = useState(true);
+  const [formData, setFormData] = useState<CursoFormState>(() => ({
+    code: "",
+    name: "",
+    startDate: "",
+    endDate: "",
+    providerId: userProviderId,
+  }));
+
+  const fallbackProviderId = useMemo(() => {
+    if (providers.some((provider) => provider.id === userProviderId)) {
+      return userProviderId;
+    }
+    return providers[0]?.id ?? "";
+  }, [providers, userProviderId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -24,17 +78,7 @@ export default function AdminCursos() {
       try {
         const apiCursos = await listarCursos();
         if (cancelled) return;
-        const mapped = apiCursos.map<CursoItem>((curso) => ({
-          id: curso.id,
-          codigo: curso.code,
-          nombre: curso.name,
-          proveedor: "—",
-          fechas: `${new Date(curso.startDate).toLocaleDateString()} – ${new Date(
-            curso.endDate
-          ).toLocaleDateString()}`,
-          instructores: []
-        }));
-        setItems(mapped);
+        setItems(apiCursos.map(mapCurso));
       } catch {
         if (!cancelled) setItems([]);
       } finally {
@@ -46,6 +90,39 @@ export default function AdminCursos() {
     };
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const apiProveedores = await listarProveedores();
+        if (cancelled) return;
+        setProviders(apiProveedores);
+      } catch {
+        if (!cancelled) setProviders([]);
+      } finally {
+        if (!cancelled) setProvidersLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    setFormData((prev) => {
+      if (!fallbackProviderId) {
+        return prev;
+      }
+
+      if (providers.some((provider) => provider.id === prev.providerId)) {
+        return prev;
+      }
+
+      return { ...prev, providerId: fallbackProviderId };
+    });
+  }, [fallbackProviderId, providers]);
+
   const cursos = useMemo(
     () =>
       items.filter((curso) =>
@@ -55,6 +132,102 @@ export default function AdminCursos() {
       ),
     [query, items]
   );
+
+  const updateFormField = (field: keyof CursoFormState) => (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { value } = event.target;
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const resetForm = () => {
+    setFormData({
+      code: "",
+      name: "",
+      startDate: "",
+      endDate: "",
+      providerId: fallbackProviderId,
+    });
+    setFormError(null);
+  };
+
+  const closeForm = () => {
+    setShowCreateForm(false);
+    resetForm();
+  };
+
+  const toggleCreateForm = () => {
+    if (showCreateForm) {
+      closeForm();
+    } else {
+      resetForm();
+      setShowCreateForm(true);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (saving) return;
+
+    const trimmed = {
+      code: formData.code.trim(),
+      name: formData.name.trim(),
+      providerId: formData.providerId.trim(),
+    };
+
+    if (!trimmed.code || !trimmed.name || !formData.startDate || !formData.endDate || !trimmed.providerId) {
+      setFormError("Completa todos los campos obligatorios.");
+      return;
+    }
+
+    if (providersLoading) {
+      setFormError("Espera a que se carguen los proveedores disponibles.");
+      return;
+    }
+
+    if (!providers.some((provider) => provider.id === trimmed.providerId)) {
+      setFormError("Selecciona un proveedor válido para el curso.");
+      return;
+    }
+
+    const start = new Date(formData.startDate);
+    const end = new Date(formData.endDate);
+
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      setFormError("Ingresa fechas válidas para el curso.");
+      return;
+    }
+
+    if (end < start) {
+      setFormError("La fecha de término debe ser posterior al inicio.");
+      return;
+    }
+
+    setSaving(true);
+    setFormError(null);
+
+    try {
+      await crearCurso({
+        code: trimmed.code,
+        name: trimmed.name,
+        startDate: formData.startDate,
+        endDate: formData.endDate,
+        providerId: trimmed.providerId,
+      });
+
+      const apiCursos = await listarCursos();
+      setItems(apiCursos.map(mapCurso));
+      closeForm();
+    } catch (error) {
+      if (error instanceof Error) {
+        setFormError(error.message);
+      } else {
+        setFormError("No se pudo crear el curso. Inténtalo nuevamente.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <section className="space-y-4">
@@ -66,12 +239,108 @@ export default function AdminCursos() {
             value={query}
             onChange={(event) => setQuery(event.target.value)}
           />
-          <Button>Nuevo curso</Button>
+          <Button
+            type="button"
+            onClick={toggleCreateForm}
+            aria-expanded={showCreateForm}
+            aria-pressed={showCreateForm}
+            className="items-center"
+          >
+            {showCreateForm ? (
+              <X size={16} className="mr-2" />
+            ) : (
+              <Plus size={16} className="mr-2" />
+            )}
+            {showCreateForm ? "Cerrar" : "Nuevo curso"}
+          </Button>
           <Button variant="ghost">
             <Settings size={16} /> Configuración
           </Button>
         </div>
       </header>
+
+      {showCreateForm ? (
+        <Card className="p-4">
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-1">
+                <Label htmlFor="nuevo-curso-codigo">Código</Label>
+                <Input
+                  id="nuevo-curso-codigo"
+                  value={formData.code}
+                  onChange={updateFormField("code")}
+                  autoComplete="off"
+                />
+              </div>
+              <div className="space-y-1 md:col-span-2">
+                <Label htmlFor="nuevo-curso-nombre">Nombre</Label>
+                <Input
+                  id="nuevo-curso-nombre"
+                  value={formData.name}
+                  onChange={updateFormField("name")}
+                  autoComplete="off"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="nuevo-curso-inicio">Fecha de inicio</Label>
+                <Input
+                  id="nuevo-curso-inicio"
+                  type="date"
+                  value={formData.startDate}
+                  onChange={updateFormField("startDate")}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="nuevo-curso-fin">Fecha de término</Label>
+                <Input
+                  id="nuevo-curso-fin"
+                  type="date"
+                  value={formData.endDate}
+                  onChange={updateFormField("endDate")}
+                />
+              </div>
+              <div className="space-y-1 md:col-span-2">
+                <Label htmlFor="nuevo-curso-proveedor">Proveedor</Label>
+                <select
+                  id="nuevo-curso-proveedor"
+                  className="input"
+                  value={formData.providerId}
+                  onChange={updateFormField("providerId")}
+                  disabled={providersLoading || providers.length === 0}
+                >
+                  <option value="" disabled>
+                    {providersLoading ? "Cargando proveedores…" : "Selecciona un proveedor"}
+                  </option>
+                  {providers.map((provider) => (
+                    <option key={provider.id} value={provider.id}>
+                      {provider.name}
+                    </option>
+                  ))}
+                </select>
+                {!providersLoading && providers.length === 0 ? (
+                  <p className="text-xs text-gray-500">
+                    No hay proveedores disponibles. Crea un proveedor antes de registrar un curso.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            {formError ? (
+              <p className="text-sm text-red-600">{formError}</p>
+            ) : null}
+
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={closeForm} disabled={saving}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={saving || providersLoading || providers.length === 0}>
+                {saving ? <Loader2 className="mr-2 animate-spin" size={16} /> : null}
+                Guardar curso
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : null}
 
       <div className="grid grid-cols-12 gap-4">
         <div className="col-span-12 space-y-4 md:col-span-8 lg:col-span-9">
@@ -95,7 +364,7 @@ export default function AdminCursos() {
               curso.proveedor,
               curso.fechas,
               <span key={`${curso.id}-i`} className="text-gray-600">
-                {curso.instructores.join(", ")}
+                {curso.instructores.length > 0 ? curso.instructores.join(", ") : "—"}
               </span>,
               <div key={`${curso.id}-a`} className="flex gap-2">
                 <Button variant="ghost">Editar</Button>

--- a/frontend/src/pages/InstructorSesiones.tsx
+++ b/frontend/src/pages/InstructorSesiones.tsx
@@ -1,17 +1,206 @@
-import { Button, Table } from "../components/ui";
+/* global HTMLFormElement */
+
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+
+import { Button, Card, Input, Label, Table } from "../components/ui";
+import { listarMisCursos, type CursoDTO } from "../services/cursos";
+import { crearSesion, listarSesionesMias, type SesionDTO } from "../services/sesiones";
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return date.toLocaleDateString();
+}
+
+function todayISODate() {
+  const today = new Date();
+  const month = `${today.getMonth() + 1}`.padStart(2, "0");
+  const day = `${today.getDate()}`.padStart(2, "0");
+  return `${today.getFullYear()}-${month}-${day}`;
+}
 
 export default function InstructorSesiones() {
-  const rows = [
-    ["2025-10-03", "CUR-001", "Seguridad en Obra", <Button key="s1" variant="ghost">Abrir</Button>],
-    ["2025-10-10", "CUR-001", "Seguridad en Obra", <Button key="s2" variant="ghost">Abrir</Button>],
-  ];
+  const [sessions, setSessions] = useState<SesionDTO[]>([]);
+  const [loadingSessions, setLoadingSessions] = useState(true);
+  const [courses, setCourses] = useState<CursoDTO[]>([]);
+  const [coursesLoading, setCoursesLoading] = useState(true);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [selectedCourseId, setSelectedCourseId] = useState("");
+  const [sessionDate, setSessionDate] = useState(todayISODate);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const loadSessions = useCallback(async () => {
+    setLoadingSessions(true);
+    try {
+      const data = await listarSesionesMias();
+      setSessions(data);
+    } catch {
+      setSessions([]);
+    } finally {
+      setLoadingSessions(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await listarMisCursos();
+        if (cancelled) return;
+        setCourses(data);
+      } catch {
+        if (!cancelled) setCourses([]);
+      } finally {
+        if (!cancelled) setCoursesLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    setSelectedCourseId((prev) => {
+      if (prev && courses.some((course) => course.id === prev)) {
+        return prev;
+      }
+      return courses[0]?.id ?? "";
+    });
+  }, [courses]);
+
+  const toggleCreateForm = () => {
+    if (showCreateForm) {
+      setShowCreateForm(false);
+      setFormError(null);
+    } else {
+      setSessionDate(todayISODate());
+      setFormError(null);
+      setShowCreateForm(true);
+    }
+  };
+
+  const closeForm = () => {
+    setShowCreateForm(false);
+    setFormError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (creating) return;
+
+    const trimmedCourseId = selectedCourseId.trim();
+    if (!trimmedCourseId) {
+      setFormError("Selecciona un curso para iniciar la sesión.");
+      return;
+    }
+
+    if (!courses.some((course) => course.id === trimmedCourseId)) {
+      setFormError("Selecciona un curso válido.");
+      return;
+    }
+
+    const date = new Date(sessionDate);
+    if (Number.isNaN(date.getTime())) {
+      setFormError("Selecciona una fecha válida.");
+      return;
+    }
+
+    setCreating(true);
+    setFormError(null);
+    try {
+      await crearSesion(trimmedCourseId, date.toISOString());
+      await loadSessions();
+      setShowCreateForm(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "No se pudo crear la sesión.";
+      setFormError(message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const rows = useMemo(() => {
+    if (loadingSessions) {
+      return [["Cargando…", "", "", ""]];
+    }
+
+    if (sessions.length === 0) {
+      return [["Sin sesiones", "", "", ""]];
+    }
+
+    return sessions.map((session) => [
+      formatDate(session.date),
+      session.course?.code ?? "—",
+      session.course?.name ?? "—",
+      <Button key={session.id} variant="ghost">Abrir</Button>
+    ]);
+  }, [loadingSessions, sessions]);
 
   return (
     <section className="space-y-4">
       <header className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Sesiones</h1>
-        <Button>Nueva sesión</Button>
+        <Button aria-expanded={showCreateForm} onClick={toggleCreateForm}>
+          {showCreateForm ? "Cerrar" : "Nueva sesión"}
+        </Button>
       </header>
+
+      {showCreateForm ? (
+        <Card className="p-4">
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <Label htmlFor="session-course">Curso</Label>
+              <select
+                id="session-course"
+                className="select select-bordered w-full"
+                value={selectedCourseId}
+                onChange={(event) => setSelectedCourseId(event.target.value)}
+                disabled={coursesLoading || courses.length === 0}
+              >
+                {coursesLoading && <option>Cargando cursos…</option>}
+                {!coursesLoading && courses.length === 0 && <option>No hay cursos disponibles</option>}
+                {!coursesLoading &&
+                  courses.map((course) => (
+                    <option key={course.id} value={course.id}>
+                      {course.code} — {course.name}
+                    </option>
+                  ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="session-date">Fecha</Label>
+              <Input
+                id="session-date"
+                type="date"
+                value={sessionDate}
+                max="9999-12-31"
+                onChange={(event) => setSessionDate(event.target.value)}
+              />
+            </div>
+
+            {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={closeForm}>
+                Cancelar
+              </Button>
+              <Button disabled={creating || coursesLoading || courses.length === 0} type="submit">
+                {creating ? "Guardando…" : "Crear sesión"}
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : null}
+
       <Table columns={["Fecha", "Código", "Curso", "Acciones"]} rows={rows} />
     </section>
   );

--- a/frontend/src/services/cursos.ts
+++ b/frontend/src/services/cursos.ts
@@ -1,4 +1,18 @@
+import { isAxiosError } from "axios";
+
 import api from "./http";
+
+type CursoInstructorDTO = {
+  user: {
+    id: string;
+    name: string | null;
+  } | null;
+};
+
+type CursoProviderDTO = {
+  id: string;
+  name: string | null;
+} | null;
 
 export type CursoDTO = {
   id: string;
@@ -7,6 +21,8 @@ export type CursoDTO = {
   startDate: string;
   endDate: string;
   providerId: string;
+  provider?: CursoProviderDTO;
+  instructors?: CursoInstructorDTO[];
   senceCode?: string | null;
 };
 
@@ -18,4 +34,29 @@ export async function listarCursos() {
 export async function listarMisCursos() {
   const { data } = await api.get<CursoDTO[]>("/cursos/mios");
   return data;
+}
+
+export type CrearCursoInput = {
+  code: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  providerId: string;
+  instructorIds?: string[];
+};
+
+export async function crearCurso(input: CrearCursoInput) {
+  try {
+    const { data } = await api.post<CursoDTO>("/cursos", input);
+    return data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const message =
+        (typeof error.response?.data === "object" && error.response?.data && "error" in error.response.data
+          ? (error.response.data as { error?: string }).error
+          : null) ?? "No se pudo crear el curso. Inténtalo nuevamente.";
+      throw new Error(message);
+    }
+    throw error;
+  }
 }

--- a/frontend/src/services/proveedores.ts
+++ b/frontend/src/services/proveedores.ts
@@ -1,0 +1,11 @@
+import api from "./http";
+
+export type ProveedorDTO = {
+  id: string;
+  name: string;
+};
+
+export async function listarProveedores() {
+  const { data } = await api.get<ProveedorDTO[]>("/proveedores");
+  return data;
+}


### PR DESCRIPTION
## Summary
- load instructor-owned sessions and courses from the API and format them for display
- add a toggleable creation form so instructors can choose a course and date when starting a new session
- refresh the sessions table after creating a session and handle loading and empty states gracefully

## Testing
- pnpm lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68de98a49b048324823aada8b173b00c