### PR TITLE
Adjust default Docker frontend port to avoid conflicts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Configuración de la base de datos
+POSTGRES_DB=regasis
+POSTGRES_USER=regasis
+POSTGRES_PASSWORD=regasis
+DATABASE_URL=postgresql://regasis:regasis@localhost:5432/regasis
+
+# Puertos publicados por Docker (ajusta si ya están en uso en tu host)
+BACKEND_PORT=4000
+FRONTEND_PORT=3000
+
+# JWT y CORS
+JWT_SECRET=super-secret-change-me
+JWT_EXPIRES=15m
+REFRESH_EXPIRES=7d
+# Si modificas FRONTEND_PORT, recuerda actualizar también este valor
+CORS_ORIGIN=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ yarn-error.log*
 .env.*.local
 
 # Prisma
-backend/prisma/migrations/
 
 # Coverage / testing
 coverage/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+coverage
+.env
+*.log
+src/**/*.spec.ts
+dist

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS base
+WORKDIR /app
+
+FROM base AS deps
+ENV NODE_ENV=development
+COPY package*.json ./
+RUN npm install --include=dev
+
+FROM base AS builder
+ENV NODE_ENV=development
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+RUN npx prisma generate
+
+FROM base AS runner
+ENV NODE_ENV=production
+COPY package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/prisma ./prisma
+RUN npm prune --omit=dev
+EXPOSE 4000
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/server.js"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "prisma generate && tsc -p tsconfig.json",
     "start": "node dist/server.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name init",
@@ -23,6 +23,7 @@
     "morgan": "^1.10.0",
     "ms": "^2.1.3",
     "multer": "^1.4.5-lts.1",
+    "prisma": "^5.19.0",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
@@ -33,7 +34,6 @@
     "@types/jsonwebtoken": "^9.0.5",
     "@types/morgan": "^1.9.7",
     "@types/multer": "^1.4.12",
-    "prisma": "^5.19.0",
     "ts-node": "^10.9.2",
     "tslib": "^2.7.0",
     "tsx": "^4.19.0",

--- a/backend/prisma/migrations/0001_init/migration.sql
+++ b/backend/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,193 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'INSTRUCTOR', 'REPORTER');
+
+-- CreateEnum
+CREATE TYPE "AttendanceState" AS ENUM ('PRESENTE', 'AUSENTE', 'JUSTIFICADO');
+
+-- CreateEnum
+CREATE TYPE "GradeType" AS ENUM ('P1', 'P2', 'EXAMEN', 'PRACTICA', 'OTRO');
+
+-- CreateTable
+CREATE TABLE "Provider" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Provider_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "role" "Role" NOT NULL,
+    "providerId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Course" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Course_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CourseInstructor" (
+    "id" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "CourseInstructor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Participant" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "providerId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Participant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Enrollment" (
+    "id" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Enrollment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attendance" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "enrollmentId" TEXT NOT NULL,
+    "state" "AttendanceState" NOT NULL,
+    "observation" TEXT,
+    "updatedById" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Attendance_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Grade" (
+    "id" TEXT NOT NULL,
+    "enrollmentId" TEXT NOT NULL,
+    "type" "GradeType" NOT NULL,
+    "score" DOUBLE PRECISION NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Grade_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT,
+    "action" TEXT NOT NULL,
+    "method" TEXT NOT NULL,
+    "path" TEXT NOT NULL,
+    "status" INTEGER NOT NULL,
+    "ip" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "jti" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revoked" BOOLEAN NOT NULL DEFAULT FALSE,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Provider_name_key" ON "Provider"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Course_code_key" ON "Course"("code");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Participant_email_key" ON "Participant"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Enrollment_participantId_courseId_key" ON "Enrollment"("participantId", "courseId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attendance_sessionId_enrollmentId_key" ON "Attendance"("sessionId", "enrollmentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_jti_key" ON "RefreshToken"("jti");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CourseInstructor_courseId_userId_key" ON "CourseInstructor"("courseId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "Provider"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Course" ADD CONSTRAINT "Course_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "Provider"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseInstructor" ADD CONSTRAINT "CourseInstructor_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseInstructor" ADD CONSTRAINT "CourseInstructor_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participant" ADD CONSTRAINT "Participant_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "Provider"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Enrollment" ADD CONSTRAINT "Enrollment_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Enrollment" ADD CONSTRAINT "Enrollment_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attendance" ADD CONSTRAINT "Attendance_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attendance" ADD CONSTRAINT "Attendance_enrollmentId_fkey" FOREIGN KEY ("enrollmentId") REFERENCES "Enrollment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attendance" ADD CONSTRAINT "Attendance_updatedById_fkey" FOREIGN KEY ("updatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Grade" ADD CONSTRAINT "Grade_enrollmentId_fkey" FOREIGN KEY ("enrollmentId") REFERENCES "Enrollment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/migration_lock.toml
+++ b/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile
+provider = "postgresql"

--- a/backend/src/routes/attendance.ts
+++ b/backend/src/routes/attendance.ts
@@ -1,26 +1,61 @@
-﻿import { Router } from "express";
-import { PrismaClient, AttendanceState } from "@prisma/client";
+import { Router, type Request, type Response } from "express";
+import { PrismaClient, type AttendanceState } from "@prisma/client";
 import { requireRole } from "../middleware/auth.js";
+
 const prisma = new PrismaClient();
 const router = Router();
 
-router.get("/session/:sessionId", requireRole("INSTRUCTOR", "ADMIN"), async (req, res) => {
-  const data = await prisma.attendance.findMany({
-    where: { sessionId: req.params.sessionId },
-    include: { enrollment: { include: { participant: true, course: true } } }
-  });
-  res.json(data);
-});
+type AttendanceParams = { sessionId: string };
 
-router.post("/session/:sessionId", requireRole("INSTRUCTOR", "ADMIN"), async (req: any, res) => {
-  const userId = req.user.id as string;
-  const sessionId = req.params.sessionId;
-  const items = req.body.items as { enrollmentId: string; state: AttendanceState; observation?: string }[];
-  const updates = await Promise.all(items.map(i => prisma.attendance.upsert({
-    where: { sessionId_enrollmentId: { sessionId, enrollmentId: i.enrollmentId } },
-    update: { state: i.state, observation: i.observation, updatedById: userId },
-    create: { sessionId, enrollmentId: i.enrollmentId, state: i.state, observation: i.observation, updatedById: userId }
-  })));
-  res.json({ updated: updates.length });
-});
+interface AttendancePayloadItem {
+  enrollmentId: string;
+  state: AttendanceState;
+  observation?: string;
+}
+
+interface AttendancePayload {
+  items?: AttendancePayloadItem[];
+}
+
+router.get(
+  "/session/:sessionId",
+  requireRole("INSTRUCTOR", "ADMIN"),
+  async (req: Request<AttendanceParams>, res: Response) => {
+    const data = await prisma.attendance.findMany({
+      where: { sessionId: req.params.sessionId },
+      include: { enrollment: { include: { participant: true, course: true } } }
+    });
+
+    return res.json(data);
+  }
+);
+
+router.post(
+  "/session/:sessionId",
+  requireRole("INSTRUCTOR", "ADMIN"),
+  async (req: Request<AttendanceParams, unknown, AttendancePayload>, res: Response) => {
+    const userId = req.user!.id;
+    const sessionId = req.params.sessionId;
+    const items = req.body?.items ?? [];
+
+    const updates = await Promise.all(
+      items.map((item) =>
+        prisma.attendance.upsert({
+          where: { sessionId_enrollmentId: { sessionId, enrollmentId: item.enrollmentId } },
+          update: { state: item.state, observation: item.observation, updatedById: userId },
+          create: {
+            sessionId,
+            enrollmentId: item.enrollmentId,
+            state: item.state,
+            observation: item.observation,
+            updatedById: userId
+          }
+        })
+      )
+    );
+
+    return res.json({ updated: updates.length });
+  }
+);
+
 export default router;

--- a/backend/src/routes/courses.ts
+++ b/backend/src/routes/courses.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response, type NextFunction } from "express";
-import { Prisma, PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { requireRole } from "../middleware/auth.js";
 import {
   listDemoCourses,
@@ -54,7 +55,7 @@ router.post(
       });
       return res.status(201).json(course);
     } catch (error) {
-      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error instanceof PrismaClientKnownRequestError) {
         if (error.code === "P2003") {
           return res.status(400).json({ error: "Proveedor inválido. Selecciona un proveedor existente." });
         }

--- a/backend/src/routes/grades.ts
+++ b/backend/src/routes/grades.ts
@@ -1,19 +1,48 @@
-﻿import { Router } from "express";
-import { PrismaClient, GradeType } from "@prisma/client";
+import { Router, type Request, type Response } from "express";
+import { PrismaClient, type GradeType } from "@prisma/client";
 import { requireRole } from "../middleware/auth.js";
+
 const prisma = new PrismaClient();
 const router = Router();
 
-router.get("/course/:courseId", requireRole("INSTRUCTOR", "ADMIN"), async (req, res) => {
-  const grades = await prisma.grade.findMany({
-    where: { enrollment: { courseId: req.params.courseId } },
-    include: { enrollment: { include: { participant: true } } }
-  });
-  res.json(grades);
-});
-router.post("/", requireRole("INSTRUCTOR", "ADMIN"), async (req, res) => {
-  const { enrollmentId, type, score, date } = req.body as { enrollmentId: string; type: GradeType; score: number; date?: string };
-  const g = await prisma.grade.create({ data: { enrollmentId, type, score, date: date? new Date(date): undefined } });
-  res.status(201).json(g);
-});
+type CourseParams = { courseId: string };
+
+interface CreateGradePayload {
+  enrollmentId: string;
+  type: GradeType;
+  score: number;
+  date?: string;
+}
+
+router.get(
+  "/course/:courseId",
+  requireRole("INSTRUCTOR", "ADMIN"),
+  async (req: Request<CourseParams>, res: Response) => {
+    const grades = await prisma.grade.findMany({
+      where: { enrollment: { courseId: req.params.courseId } },
+      include: { enrollment: { include: { participant: true } } }
+    });
+
+    return res.json(grades);
+  }
+);
+
+router.post(
+  "/",
+  requireRole("INSTRUCTOR", "ADMIN"),
+  async (req: Request<unknown, unknown, CreateGradePayload>, res: Response) => {
+    const { enrollmentId, type, score, date } = req.body;
+    const grade = await prisma.grade.create({
+      data: {
+        enrollmentId,
+        type,
+        score,
+        date: date ? new Date(date) : undefined
+      }
+    });
+
+    return res.status(201).json(grade);
+  }
+);
+
 export default router;

--- a/backend/src/routes/providers.ts
+++ b/backend/src/routes/providers.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response, type NextFunction } from "express";
-import { Prisma, PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 
 import { requireRole } from "../middleware/auth.js";
 import { isPrismaUnavailable } from "../utils/prisma.js";
@@ -46,7 +47,7 @@ router.post(
       });
       return res.status(201).json(provider);
     } catch (error) {
-      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error instanceof PrismaClientKnownRequestError) {
         if (error.code === "P2002") {
           return res
             .status(400)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-regasis}
+      POSTGRES_USER: ${POSTGRES_USER:-regasis}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-regasis}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-regasis} -d ${POSTGRES_DB:-regasis}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build: ./backend
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-regasis}:${POSTGRES_PASSWORD:-regasis}@db:5432/${POSTGRES_DB:-regasis}
+      PORT: ${BACKEND_PORT:-4000}
+      NODE_ENV: production
+      JWT_SECRET: ${JWT_SECRET:-changeme}
+      JWT_EXPIRES: ${JWT_EXPIRES:-15m}
+      REFRESH_EXPIRES: ${REFRESH_EXPIRES:-7d}
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:${FRONTEND_PORT:-3000}}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${BACKEND_PORT:-4000}:4000"
+
+  frontend:
+    build: ./frontend
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - "${FRONTEND_PORT:-3000}:80"
+
+volumes:
+  postgres-data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+coverage
+.env
+*.log
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json ./
+RUN npm install
+
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runner
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,32 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /api/ {
+    proxy_pass http://backend:4000/api/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location = /api {
+    proxy_pass http://backend:4000/api;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "regasis",
+  "private": true,
+  "version": "0.1.0",
+  "packageManager": "pnpm@9.11.0",
+  "scripts": {
+    "dev": "pnpm -r --parallel --stream run dev",
+    "dev:backend": "pnpm --filter ./backend run dev",
+    "dev:frontend": "pnpm --filter ./frontend run dev",
+    "build": "pnpm -r run build"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - backend
+  - frontend


### PR DESCRIPTION
## Summary
- change the default frontend port exposed by Docker to 3000 to dodge clashes with services already using 8080
- align the example environment defaults and backend CORS fallback with the new frontend port
- add the initial Prisma migration so the database schema is created automatically during container startup
- document a default `DATABASE_URL` in the example environment file for local development

## Testing
- Not run (dependency installation blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dece492d308324baec76654145d576