### PR TITLE
Add import job tracking and evaluation scheme support

### DIFF
--- a/backend/prisma/migrations/0002_import_jobs/migration.sql
+++ b/backend/prisma/migrations/0002_import_jobs/migration.sql
@@ -1,0 +1,159 @@
+-- CreateEnum
+CREATE TYPE "CourseStatus" AS ENUM ('DRAFT', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "ImportStatus" AS ENUM ('PENDING', 'PROCESSING', 'COMPLETED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "documentNumber" TEXT,
+ADD COLUMN     "documentType" TEXT,
+ADD COLUMN     "firstName" TEXT,
+ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "lastName" TEXT,
+ADD COLUMN     "phone" TEXT;
+
+-- AlterTable
+ALTER TABLE "Course" ADD COLUMN     "description" TEXT,
+ADD COLUMN     "location" TEXT,
+ADD COLUMN     "modality" TEXT,
+ADD COLUMN     "status" "CourseStatus" NOT NULL DEFAULT 'DRAFT';
+
+-- AlterTable
+ALTER TABLE "Enrollment" ADD COLUMN     "importJobId" TEXT,
+ADD COLUMN     "role" TEXT,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "Attendance" ADD COLUMN     "importJobId" TEXT,
+ADD COLUMN     "justification" TEXT;
+
+-- AlterTable
+ALTER TABLE "Grade" ADD COLUMN     "evaluationSchemeId" TEXT,
+ADD COLUMN     "importJobId" TEXT,
+ADD COLUMN     "observation" TEXT;
+
+-- CreateTable
+CREATE TABLE "EvaluationScheme" (
+    "id" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "gradeType" "GradeType" NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL,
+    "minScore" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "maxScore" DOUBLE PRECISION NOT NULL DEFAULT 20,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EvaluationScheme_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Document" (
+    "id" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "checksum" TEXT,
+    "url" TEXT,
+    "metadata" JSONB,
+    "createdById" TEXT NOT NULL,
+    "providerId" TEXT,
+    "courseId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ImportJob" (
+    "id" TEXT NOT NULL,
+    "status" "ImportStatus" NOT NULL DEFAULT 'PENDING',
+    "kind" TEXT NOT NULL,
+    "providerId" TEXT,
+    "courseId" TEXT,
+    "documentId" TEXT,
+    "createdById" TEXT NOT NULL,
+    "totalRows" INTEGER NOT NULL DEFAULT 0,
+    "processedRows" INTEGER NOT NULL DEFAULT 0,
+    "successCount" INTEGER NOT NULL DEFAULT 0,
+    "failureCount" INTEGER NOT NULL DEFAULT 0,
+    "errorMessage" TEXT,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ImportJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Document_providerId_idx" ON "Document"("providerId");
+
+-- CreateIndex
+CREATE INDEX "Document_courseId_idx" ON "Document"("courseId");
+
+-- CreateIndex
+CREATE INDEX "Document_createdById_idx" ON "Document"("createdById");
+
+-- CreateIndex
+CREATE INDEX "ImportJob_providerId_idx" ON "ImportJob"("providerId");
+
+-- CreateIndex
+CREATE INDEX "ImportJob_courseId_idx" ON "ImportJob"("courseId");
+
+-- CreateIndex
+CREATE INDEX "ImportJob_documentId_idx" ON "ImportJob"("documentId");
+
+-- CreateIndex
+CREATE INDEX "ImportJob_createdById_idx" ON "ImportJob"("createdById");
+
+-- CreateIndex
+CREATE INDEX "Enrollment_importJobId_idx" ON "Enrollment"("importJobId");
+
+-- CreateIndex
+CREATE INDEX "Attendance_importJobId_idx" ON "Attendance"("importJobId");
+
+-- CreateIndex
+CREATE INDEX "Grade_evaluationSchemeId_idx" ON "Grade"("evaluationSchemeId");
+
+-- CreateIndex
+CREATE INDEX "Grade_importJobId_idx" ON "Grade"("importJobId");
+
+-- AddForeignKey
+ALTER TABLE "Enrollment" ADD CONSTRAINT "Enrollment_importJobId_fkey" FOREIGN KEY ("importJobId") REFERENCES "ImportJob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attendance" ADD CONSTRAINT "Attendance_importJobId_fkey" FOREIGN KEY ("importJobId") REFERENCES "ImportJob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Grade" ADD CONSTRAINT "Grade_evaluationSchemeId_fkey" FOREIGN KEY ("evaluationSchemeId") REFERENCES "EvaluationScheme"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Grade" ADD CONSTRAINT "Grade_importJobId_fkey" FOREIGN KEY ("importJobId") REFERENCES "ImportJob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EvaluationScheme" ADD CONSTRAINT "EvaluationScheme_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "Provider"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ImportJob" ADD CONSTRAINT "ImportJob_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "Provider"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ImportJob" ADD CONSTRAINT "ImportJob_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ImportJob" ADD CONSTRAINT "ImportJob_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ImportJob" ADD CONSTRAINT "ImportJob_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,20 @@ enum GradeType {
   OTRO
 }
 
+enum CourseStatus {
+  DRAFT
+  IN_PROGRESS
+  COMPLETED
+  CANCELLED
+}
+
+enum ImportStatus {
+  PENDING
+  PROCESSING
+  COMPLETED
+  FAILED
+}
+
 model Provider {
   id           String        @id @default(cuid())
   name         String        @unique
@@ -34,38 +48,55 @@ model Provider {
   updatedAt    DateTime      @updatedAt
   users        User[]
   courses      Course[]
-  participants Participant[]   // inverso de Participant.provider
+  participants Participant[] // inverso de Participant.provider
+  documents    Document[]
+  importJobs   ImportJob[]
 }
 
 model User {
-  id                 String        @id @default(cuid())
-  email              String        @unique
+  id                 String             @id @default(cuid())
+  email              String             @unique
   name               String
+  firstName          String?
+  lastName           String?
+  documentType       String?
+  documentNumber     String?
+  phone              String?
+  isActive           Boolean            @default(true)
   password           String
   role               Role
   providerId         String?
-  provider           Provider?     @relation(fields: [providerId], references: [id])
-  createdAt          DateTime      @default(now())
-  updatedAt          DateTime      @updatedAt
+  provider           Provider?          @relation(fields: [providerId], references: [id])
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
   instructorOf       CourseInstructor[]
   auditLogs          AuditLog[]
   refreshTokens      RefreshToken[]
-  updatedAttendances Attendance[]  @relation("UserUpdatedAttendances") // inverso de Attendance.updatedBy
+  updatedAttendances Attendance[]       @relation("UserUpdatedAttendances") // inverso de Attendance.updatedBy
+  documents          Document[]
+  createdImportJobs  ImportJob[]        @relation("UserCreatedImportJobs")
 }
 
 model Course {
-  id          String            @id @default(cuid())
-  code        String            @unique
-  name        String
-  startDate   DateTime
-  endDate     DateTime
-  providerId  String
-  provider    Provider          @relation(fields: [providerId], references: [id])
-  instructors CourseInstructor[]
-  sessions    Session[]
-  enrollments Enrollment[]
-  createdAt   DateTime          @default(now())
-  updatedAt   DateTime          @updatedAt
+  id                String             @id @default(cuid())
+  code              String             @unique
+  name              String
+  startDate         DateTime
+  endDate           DateTime
+  providerId        String
+  provider          Provider           @relation(fields: [providerId], references: [id])
+  status            CourseStatus       @default(DRAFT)
+  description       String?
+  location          String?
+  modality          String?
+  instructors       CourseInstructor[]
+  sessions          Session[]
+  enrollments       Enrollment[]
+  evaluationSchemes EvaluationScheme[]
+  documents         Document[]
+  importJobs        ImportJob[]
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
 }
 
 model CourseInstructor {
@@ -79,14 +110,14 @@ model CourseInstructor {
 }
 
 model Participant {
-  id         String       @id @default(cuid())
-  email      String       @unique
-  name       String
-  providerId String?
-  provider   Provider?    @relation(fields: [providerId], references: [id])
+  id          String       @id @default(cuid())
+  email       String       @unique
+  name        String
+  providerId  String?
+  provider    Provider?    @relation(fields: [providerId], references: [id])
   enrollments Enrollment[]
-  createdAt  DateTime     @default(now())
-  updatedAt  DateTime     @updatedAt
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
 }
 
 model Enrollment {
@@ -95,44 +126,130 @@ model Enrollment {
   courseId      String
   participant   Participant  @relation(fields: [participantId], references: [id])
   course        Course       @relation(fields: [courseId], references: [id])
-  attendance    Attendance[]   // inverso de Attendance.enrollment
-  grades        Grade[]        // inverso de Grade.enrollment
+  attendance    Attendance[] // inverso de Attendance.enrollment
+  grades        Grade[] // inverso de Grade.enrollment
   createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
+  role          String?
+  importJobId   String?
+  importJob     ImportJob?   @relation("EnrollmentImportJob", fields: [importJobId], references: [id])
 
   @@unique([participantId, courseId])
+  @@index([importJobId])
 }
 
 model Session {
-  id        String       @id @default(cuid())
-  courseId  String
-  date      DateTime
-  course    Course       @relation(fields: [courseId], references: [id])
+  id         String       @id @default(cuid())
+  courseId   String
+  date       DateTime
+  course     Course       @relation(fields: [courseId], references: [id])
   attendance Attendance[]
 }
 
 model Attendance {
-  id            String     @id @default(cuid())
+  id            String          @id @default(cuid())
   sessionId     String
   enrollmentId  String
   state         AttendanceState
   observation   String?
-  session       Session    @relation(fields: [sessionId], references: [id])
-  enrollment    Enrollment @relation(fields: [enrollmentId], references: [id])
+  session       Session         @relation(fields: [sessionId], references: [id])
+  enrollment    Enrollment      @relation(fields: [enrollmentId], references: [id])
   updatedById   String?
-  updatedBy     User?      @relation("UserUpdatedAttendances", fields: [updatedById], references: [id])
-  updatedAt     DateTime   @updatedAt
-  createdAt     DateTime   @default(now())
+  updatedBy     User?           @relation("UserUpdatedAttendances", fields: [updatedById], references: [id])
+  justification String?
+  importJobId   String?
+  importJob     ImportJob?      @relation("AttendanceImportJob", fields: [importJobId], references: [id])
+  updatedAt     DateTime        @updatedAt
+  createdAt     DateTime        @default(now())
 
   @@unique([sessionId, enrollmentId])
+  @@index([importJobId])
 }
 
 model Grade {
-  id           String     @id @default(cuid())
-  enrollmentId String
-  type         GradeType
-  score        Float
-  date         DateTime   @default(now())
-  enrollment   Enrollment @relation(fields: [enrollmentId], references: [id])
+  id                 String            @id @default(cuid())
+  enrollmentId       String
+  type               GradeType
+  score              Float
+  date               DateTime          @default(now())
+  enrollment         Enrollment        @relation(fields: [enrollmentId], references: [id])
+  evaluationSchemeId String?
+  evaluationScheme   EvaluationScheme? @relation(fields: [evaluationSchemeId], references: [id])
+  observation        String?
+  importJobId        String?
+  importJob          ImportJob?        @relation("GradeImportJob", fields: [importJobId], references: [id])
+
+  @@index([evaluationSchemeId])
+  @@index([importJobId])
+}
+
+model EvaluationScheme {
+  id        String    @id @default(cuid())
+  courseId  String
+  label     String
+  gradeType GradeType
+  weight    Float
+  minScore  Float     @default(0)
+  maxScore  Float     @default(20)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  course    Course    @relation(fields: [courseId], references: [id])
+  grades    Grade[]
+}
+
+model Document {
+  id           String      @id @default(cuid())
+  filename     String
+  originalName String
+  mimeType     String
+  size         Int
+  checksum     String?
+  url          String?
+  metadata     Json?
+  createdById  String
+  providerId   String?
+  courseId     String?
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
+  createdBy    User        @relation(fields: [createdById], references: [id])
+  provider     Provider?   @relation(fields: [providerId], references: [id])
+  course       Course?     @relation(fields: [courseId], references: [id])
+  importJobs   ImportJob[] @relation("ImportJobSourceDocument")
+
+  @@index([providerId])
+  @@index([courseId])
+  @@index([createdById])
+}
+
+model ImportJob {
+  id            String       @id @default(cuid())
+  status        ImportStatus @default(PENDING)
+  kind          String
+  providerId    String?
+  courseId      String?
+  documentId    String?
+  createdById   String
+  totalRows     Int          @default(0)
+  processedRows Int          @default(0)
+  successCount  Int          @default(0)
+  failureCount  Int          @default(0)
+  errorMessage  String?
+  startedAt     DateTime?
+  completedAt   DateTime?
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
+  provider      Provider?    @relation(fields: [providerId], references: [id])
+  course        Course?      @relation(fields: [courseId], references: [id])
+  document      Document?    @relation("ImportJobSourceDocument", fields: [documentId], references: [id])
+  createdBy     User         @relation("UserCreatedImportJobs", fields: [createdById], references: [id])
+  enrollments   Enrollment[] @relation("EnrollmentImportJob")
+  attendances   Attendance[] @relation("AttendanceImportJob")
+  grades        Grade[]      @relation("GradeImportJob")
+
+  @@index([providerId])
+  @@index([courseId])
+  @@index([documentId])
+  @@index([createdById])
 }
 
 model AuditLog {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,8 +1,9 @@
-﻿import { PrismaClient, Role } from "@prisma/client";
+import { PrismaClient, Role, CourseStatus, GradeType } from "@prisma/client";
 import { hashPassword } from "../src/utils/crypto.js";
+
 const prisma = new PrismaClient();
 
-async function main(){
+async function main() {
   const provider = await prisma.provider.upsert({
     where: { name: "ACME Capacitación" },
     update: {},
@@ -13,27 +14,41 @@ async function main(){
     where: { email: "admin@org" },
     update: {},
     create: {
-      email: "admin@org", name: "Admin",
+      email: "admin@org",
+      name: "Admin",
+      firstName: "Admin",
+      lastName: "Principal",
       password: await hashPassword("admin123"),
-      role: Role.ADMIN, providerId: provider.id
+      role: Role.ADMIN,
+      providerId: provider.id
     }
   });
+
   const inst = await prisma.user.upsert({
     where: { email: "instructor@org" },
     update: {},
     create: {
-      email: "instructor@org", name: "Instr",
+      email: "instructor@org",
+      name: "Instr",
+      firstName: "Inés",
+      lastName: "Tructor",
       password: await hashPassword("instructor123"),
-      role: Role.INSTRUCTOR, providerId: provider.id
+      role: Role.INSTRUCTOR,
+      providerId: provider.id
     }
   });
+
   await prisma.user.upsert({
     where: { email: "reporter@org" },
     update: {},
     create: {
-      email: "reporter@org", name: "Reporter",
+      email: "reporter@org",
+      name: "Reporter",
+      firstName: "Rey",
+      lastName: "Porter",
       password: await hashPassword("reporter123"),
-      role: Role.REPORTER, providerId: provider.id
+      role: Role.REPORTER,
+      providerId: provider.id
     }
   });
 
@@ -41,40 +56,103 @@ async function main(){
     where: { code: "CUR-001" },
     update: {},
     create: {
-      code: "CUR-001", name: "Seguridad en Obra",
-      startDate: new Date("2025-10-02"), endDate: new Date("2025-10-30"),
-      providerId: provider.id
+      code: "CUR-001",
+      name: "Seguridad en Obra",
+      startDate: new Date("2025-10-02"),
+      endDate: new Date("2025-10-30"),
+      providerId: provider.id,
+      status: CourseStatus.IN_PROGRESS,
+      description: "Curso introductorio a la seguridad industrial",
+      location: "Sala 1",
+      modality: "Presencial"
     }
   });
+
+  await prisma.evaluationScheme.deleteMany({ where: { courseId: course.id } });
+  const examScheme = await prisma.evaluationScheme.create({
+    data: {
+      courseId: course.id,
+      label: "Examen Final",
+      gradeType: GradeType.EXAMEN,
+      weight: 0.6,
+      minScore: 0,
+      maxScore: 20
+    }
+  });
+  const practiceScheme = await prisma.evaluationScheme.create({
+    data: {
+      courseId: course.id,
+      label: "Prácticas",
+      gradeType: GradeType.PRACTICA,
+      weight: 0.4,
+      minScore: 0,
+      maxScore: 20
+    }
+  });
+
   await prisma.courseInstructor.upsert({
     where: { courseId_userId: { courseId: course.id, userId: inst.id } },
-    update: {}, create: { courseId: course.id, userId: inst.id }
+    update: {},
+    create: { courseId: course.id, userId: inst.id }
   });
 
   const p1 = await prisma.participant.upsert({
     where: { email: "ana@example.com" },
-    update: {}, create: { email: "ana@example.com", name: "Ana Soto", providerId: provider.id }
+    update: {},
+    create: { email: "ana@example.com", name: "Ana Soto", providerId: provider.id }
   });
   const p2 = await prisma.participant.upsert({
     where: { email: "leo@example.com" },
-    update: {}, create: { email: "leo@example.com", name: "Leandro Ruiz", providerId: provider.id }
+    update: {},
+    create: { email: "leo@example.com", name: "Leandro Ruiz", providerId: provider.id }
   });
 
   const e1 = await prisma.enrollment.upsert({
     where: { participantId_courseId: { participantId: p1.id, courseId: course.id } },
-    update: {}, create: { participantId: p1.id, courseId: course.id }
+    update: { role: "Alumno" },
+    create: { participantId: p1.id, courseId: course.id, role: "Alumno" }
   });
   const e2 = await prisma.enrollment.upsert({
     where: { participantId_courseId: { participantId: p2.id, courseId: course.id } },
-    update: {}, create: { participantId: p2.id, courseId: course.id }
+    update: { role: "Alumno" },
+    create: { participantId: p2.id, courseId: course.id, role: "Alumno" }
   });
 
-  const s1 = await prisma.session.create({ data: { courseId: course.id, date: new Date("2025-10-03") } });
+  const s1 = await prisma.session.create({
+    data: { courseId: course.id, date: new Date("2025-10-03") }
+  });
 
-  await prisma.attendance.createMany({ data: [
-    { sessionId: s1.id, enrollmentId: e1.id, state: "PRESENTE" },
-    { sessionId: s1.id, enrollmentId: e2.id, state: "AUSENTE" }
-  ]});
+  await prisma.attendance.createMany({
+    data: [
+      { sessionId: s1.id, enrollmentId: e1.id, state: "PRESENTE" },
+      { sessionId: s1.id, enrollmentId: e2.id, state: "AUSENTE" }
+    ]
+  });
+
+  await prisma.grade.createMany({
+    data: [
+      {
+        enrollmentId: e1.id,
+        type: GradeType.EXAMEN,
+        score: 18,
+        evaluationSchemeId: examScheme.id
+      },
+      {
+        enrollmentId: e1.id,
+        type: GradeType.PRACTICA,
+        score: 16,
+        evaluationSchemeId: practiceScheme.id
+      }
+    ],
+    skipDuplicates: true
+  });
+
   console.log({ admin: admin.email, course: course.code });
 }
-main().finally(()=>prisma.$disconnect());
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/backend/src/routes/attendance.ts
+++ b/backend/src/routes/attendance.ts
@@ -11,6 +11,7 @@ interface AttendancePayloadItem {
   enrollmentId: string;
   state: AttendanceState;
   observation?: string;
+  justification?: string;
 }
 
 interface AttendancePayload {
@@ -42,12 +43,18 @@ router.post(
       items.map((item) =>
         prisma.attendance.upsert({
           where: { sessionId_enrollmentId: { sessionId, enrollmentId: item.enrollmentId } },
-          update: { state: item.state, observation: item.observation, updatedById: userId },
+          update: {
+            state: item.state,
+            observation: item.observation,
+            justification: item.justification,
+            updatedById: userId
+          },
           create: {
             sessionId,
             enrollmentId: item.enrollmentId,
             state: item.state,
             observation: item.observation,
+            justification: item.justification,
             updatedById: userId
           }
         })

--- a/backend/src/routes/grades.ts
+++ b/backend/src/routes/grades.ts
@@ -12,6 +12,8 @@ interface CreateGradePayload {
   type: GradeType;
   score: number;
   date?: string;
+  evaluationSchemeId?: string;
+  observation?: string;
 }
 
 router.get(
@@ -20,7 +22,7 @@ router.get(
   async (req: Request<CourseParams>, res: Response) => {
     const grades = await prisma.grade.findMany({
       where: { enrollment: { courseId: req.params.courseId } },
-      include: { enrollment: { include: { participant: true } } }
+      include: { enrollment: { include: { participant: true } }, evaluationScheme: true }
     });
 
     return res.json(grades);
@@ -31,13 +33,15 @@ router.post(
   "/",
   requireRole("INSTRUCTOR", "ADMIN"),
   async (req: Request<unknown, unknown, CreateGradePayload>, res: Response) => {
-    const { enrollmentId, type, score, date } = req.body;
+    const { enrollmentId, type, score, date, evaluationSchemeId, observation } = req.body;
     const grade = await prisma.grade.create({
       data: {
         enrollmentId,
         type,
         score,
-        date: date ? new Date(date) : undefined
+        date: date ? new Date(date) : undefined,
+        evaluationSchemeId,
+        observation
       }
     });
 

--- a/backend/src/routes/imports.ts
+++ b/backend/src/routes/imports.ts
@@ -1,6 +1,8 @@
+import { createHash, randomUUID } from "node:crypto";
+
 import { Router } from "express";
 import multer from "multer";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, ImportStatus, Prisma } from "@prisma/client";
 import { utils, write } from "xlsx";
 
 import { requireRole } from "../middleware/auth.js";
@@ -59,69 +61,193 @@ function createTemplateWorkbook(): Buffer {
 
 const TEMPLATE_BUFFER = createTemplateWorkbook();
 
+const PARTICIPANT_IMPORT_KIND = "PARTICIPANT_ENROLLMENT";
+
 router.post("/participantes", requireRole("ADMIN"), upload.single("file"), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: "Archivo requerido" });
 
+  const user = req.user!;
   const rows = await parseCsv(req.file.buffer, req.file.mimetype);
+  const checksum = createHash("sha256").update(req.file.buffer).digest("hex");
+  const generatedName = randomUUID();
+  const metadata: Prisma.JsonObject = {
+    fieldname: req.file.fieldname ?? "file",
+    encoding: req.file.encoding ?? "",
+    totalRows: rows.length
+  };
+
+  const document = await prisma.document.create({
+    data: {
+      filename: generatedName,
+      originalName: req.file.originalname || generatedName,
+      mimeType: req.file.mimetype || "application/octet-stream",
+      size: req.file.size,
+      checksum,
+      metadata,
+      createdById: user.id
+    }
+  });
+
+  const importJob = await prisma.importJob.create({
+    data: {
+      kind: PARTICIPANT_IMPORT_KIND,
+      status: ImportStatus.PROCESSING,
+      documentId: document.id,
+      createdById: user.id,
+      totalRows: rows.length,
+      startedAt: new Date()
+    }
+  });
+
   let created = 0;
   let updated = 0;
   const errors: string[] = [];
+  const providerIds = new Set<string>();
+  const courseIds = new Set<string>();
 
   const requiredFields = ["email", "nombre", "proveedor", "codigo_curso"] as const;
 
-  for (const [idx, row] of rows.entries()) {
-    try {
-      const missingFields = requiredFields.filter((field) => {
-        const value = row[field];
-        return typeof value !== "string" || value.trim().length === 0;
-      });
-      if (missingFields.length > 0) {
-        throw new Error(`Faltan datos obligatorios (${missingFields.join(", ")})`);
+  let fatalError: unknown;
+
+  try {
+    for (const [idx, row] of rows.entries()) {
+      try {
+        const missingFields = requiredFields.filter((field) => {
+          const value = row[field];
+          return typeof value !== "string" || value.trim().length === 0;
+        });
+        if (missingFields.length > 0) {
+          throw new Error(`Faltan datos obligatorios (${missingFields.join(", ")})`);
+        }
+
+        const email = row.email.trim();
+        const providerName = row.proveedor.trim();
+        const courseCode = row.codigo_curso.trim();
+
+        const provider = await prisma.provider.upsert({
+          where: { name: providerName },
+          update: {},
+          create: { name: providerName }
+        });
+        providerIds.add(provider.id);
+
+        const course = await prisma.course.findUnique({ where: { code: courseCode } });
+        if (!course) throw new Error(`Curso ${courseCode} no existe`);
+        courseIds.add(course.id);
+
+        const firstName = row.nombre.trim();
+        const lastName = typeof row.apellido === "string" ? row.apellido.trim() : "";
+        const fullName = lastName ? `${firstName} ${lastName}` : firstName;
+
+        const participant = await prisma.participant.upsert({
+          where: { email },
+          update: { name: fullName, providerId: provider.id },
+          create: { email, name: fullName, providerId: provider.id }
+        });
+
+        const before = await prisma.enrollment.findUnique({
+          where: { participantId_courseId: { participantId: participant.id, courseId: course.id } }
+        });
+
+        if (before) updated += 1;
+
+        const role = typeof row.rol_en_curso === "string" ? row.rol_en_curso.trim() : undefined;
+
+        await prisma.enrollment.upsert({
+          where: { participantId_courseId: { participantId: participant.id, courseId: course.id } },
+          update: {
+            role: role || undefined,
+            importJobId: importJob.id
+          },
+          create: {
+            participantId: participant.id,
+            courseId: course.id,
+            role: role || undefined,
+            importJobId: importJob.id
+          }
+        });
+
+        if (!before) created += 1;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Error desconocido";
+        errors.push(`Fila ${idx + 1}: ${message}`);
       }
-
-      const email = row.email.trim();
-      const providerName = row.proveedor.trim();
-      const courseCode = row.codigo_curso.trim();
-
-      const provider = await prisma.provider.upsert({
-        where: { name: providerName },
-        update: {},
-        create: { name: providerName }
-      });
-
-      const course = await prisma.course.findUnique({ where: { code: courseCode } });
-      if (!course) throw new Error(`Curso ${courseCode} no existe`);
-
-      const firstName = row.nombre.trim();
-      const lastName = typeof row.apellido === "string" ? row.apellido.trim() : "";
-      const fullName = lastName ? `${firstName} ${lastName}` : firstName;
-
-      const participant = await prisma.participant.upsert({
-        where: { email },
-        update: { name: fullName, providerId: provider.id },
-        create: { email, name: fullName, providerId: provider.id }
-      });
-
-      const before = await prisma.enrollment.findUnique({
-        where: { participantId_courseId: { participantId: participant.id, courseId: course.id } }
-      });
-
-      if (before) updated += 1;
-
-      await prisma.enrollment.upsert({
-        where: { participantId_courseId: { participantId: participant.id, courseId: course.id } },
-        update: {},
-        create: { participantId: participant.id, courseId: course.id }
-      });
-
-      if (!before) created += 1;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Error desconocido";
-      errors.push(`Fila ${idx + 1}: ${message}`);
     }
+  } catch (error) {
+    fatalError = error;
   }
 
-  res.json({ created, updated, errors, total: rows.length });
+  const processedRows = created + updated + errors.length;
+  const providerIdForJob = providerIds.size === 1 ? [...providerIds][0] : undefined;
+  const courseIdForJob = courseIds.size === 1 ? [...courseIds][0] : undefined;
+  const now = new Date();
+
+  const baseUpdate = {
+    processedRows,
+    successCount: created + updated,
+    failureCount: errors.length,
+    completedAt: now
+  } satisfies Partial<Prisma.ImportJobUpdateInput>;
+
+  if (fatalError) {
+    const message =
+      fatalError instanceof Error
+        ? fatalError.message
+        : "Error inesperado durante la importación";
+    await prisma.importJob.update({
+      where: { id: importJob.id },
+      data: {
+        ...baseUpdate,
+        status: ImportStatus.FAILED,
+        providerId: providerIdForJob,
+        courseId: courseIdForJob,
+        failureCount: errors.length + 1,
+        errorMessage: message
+      }
+    });
+
+    if (providerIdForJob || courseIdForJob) {
+      await prisma.document.update({
+        where: { id: document.id },
+        data: {
+          providerId: providerIdForJob,
+          courseId: courseIdForJob
+        }
+      });
+    }
+
+    return res.status(500).json({
+      error: message,
+      created,
+      updated,
+      errors,
+      total: rows.length,
+      importJobId: importJob.id
+    });
+  }
+
+  await prisma.importJob.update({
+    where: { id: importJob.id },
+    data: {
+      ...baseUpdate,
+      status: ImportStatus.COMPLETED,
+      providerId: providerIdForJob,
+      courseId: courseIdForJob,
+      errorMessage: errors.length ? errors.join("\n") : undefined
+    }
+  });
+
+  if (providerIdForJob || courseIdForJob) {
+    await prisma.document.update({
+      where: { id: document.id },
+      data: {
+        providerId: providerIdForJob,
+        courseId: courseIdForJob
+      }
+    });
+  }
+
+  res.json({ created, updated, errors, total: rows.length, importJobId: importJob.id });
 });
 
 router.get("/participantes/plantilla", requireRole("ADMIN"), (_req, res) => {

--- a/backend/src/services/report.ts
+++ b/backend/src/services/report.ts
@@ -20,7 +20,8 @@ export async function reportCalificaciones({ providerId, from, to }:{ providerId
       enrollment: { course: providerId ? { providerId } : undefined }
     },
     include: {
-      enrollment: { include: { participant: true, course: true } }
+      enrollment: { include: { participant: true, course: true } },
+      evaluationScheme: true
     }
   });
 }


### PR DESCRIPTION
## Summary
- extend the Prisma schema with CourseStatus and ImportStatus enums, enrich existing tables, and add the EvaluationScheme, Document, and ImportJob models
- update seeds, demo data, and SQL DDL to populate and expose the new relationships and attributes
- adjust backend routes and services to work with the extended data model and track participant imports, and add the generated migration

## Testing
- npx prisma format
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68e04e2d1460832489a5080921d6d07e