### PR TITLE
Switch backend runtime to Debian-based image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-alpine AS base
-RUN apk add --no-cache openssl1.1-compat
+FROM node:20-bookworm-slim AS base
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 FROM base AS deps


### PR DESCRIPTION
## Summary
- replace the backend Docker image with the Debian-based Node 20 variant and install OpenSSL through apt to match Prisma's query engine binaries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04d85abe083248f79d28c3f22c25c