### PR TITLE
Fix Prisma engine binary selection for Docker runtime

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,10 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-alpine AS base
-RUN apk add --no-cache openssl1.1-compat
+FROM node:20-bookworm-slim AS base
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl libssl3 \
+  && rm -rf /var/lib/apt/lists/*
+ENV PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x"
 WORKDIR /app
 
 FROM base AS deps

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- install the OpenSSL runtime library explicitly in the backend container and pin Prisma to the Debian OpenSSL 3 engine target
- configure the Prisma client generator to ship the Debian OpenSSL 3 binary alongside the native build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04d85abe083248f79d28c3f22c25c