### PR TITLE
Switch project tooling to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 ﻿# Dependencias
 node_modules/
 pnpm-lock.yaml
-package-lock.json
 yarn.lock
 
 # Build outputs

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,18 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-alpine AS base
-RUN apk add --no-cache openssl1.1-compat
+FROM node:20-bookworm-slim AS base
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl libssl3 ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+ENV PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x"
+ENV PRISMA_QUERY_ENGINE_LIBRARY="/app/node_modules/@prisma/engines/libquery_engine-debian-openssl-3.0.x.so.node"
+ENV PRISMA_SCHEMA_ENGINE_BINARY="/app/node_modules/@prisma/engines/schema-engine-debian-openssl-3.0.x"
 WORKDIR /app
 
 FROM base AS deps
 ENV NODE_ENV=development
 COPY package*.json ./
-RUN npm install --include=dev
+RUN npm install
 
 FROM base AS builder
 ENV NODE_ENV=development

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-alpine AS base
 WORKDIR /app
 
 FROM base AS deps
-COPY package.json ./
+COPY package*.json ./
 RUN npm install
 
 FROM base AS builder

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "regasis",
   "private": true,
   "version": "0.1.0",
-  "packageManager": "pnpm@9.11.0",
+  "packageManager": "npm@10.8.1",
   "scripts": {
-    "dev": "pnpm -r --parallel --stream run dev",
-    "dev:backend": "pnpm --filter ./backend run dev",
-    "dev:frontend": "pnpm --filter ./frontend run dev",
-    "build": "pnpm -r run build"
+    "dev": "node scripts/dev.js",
+    "dev:backend": "npm --prefix backend run dev",
+    "dev:frontend": "npm --prefix frontend run dev",
+    "build": "npm run build:backend && npm run build:frontend",
+    "build:backend": "npm --prefix backend run build",
+    "build:frontend": "npm --prefix frontend run build"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-packages:
-  - backend
-  - frontend

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,91 @@
+const { spawn } = require('node:child_process');
+const { createInterface } = require('node:readline');
+
+const commands = [
+  {
+    name: 'backend',
+    cmd: 'npm',
+    args: ['--prefix', 'backend', 'run', 'dev']
+  },
+  {
+    name: 'frontend',
+    cmd: 'npm',
+    args: ['--prefix', 'frontend', 'run', 'dev']
+  }
+];
+
+const children = [];
+let shuttingDown = false;
+
+function attachOutput(stream, destination, name) {
+  if (!stream) {
+    return;
+  }
+
+  const reader = createInterface({ input: stream });
+  reader.on('line', (line) => {
+    destination.write(`[${name}] ${line}\n`);
+  });
+}
+
+function stopChildren(signal = 'SIGINT') {
+  shuttingDown = true;
+  const terminationSignal = process.platform === 'win32' && signal === 'SIGINT' ? 'SIGTERM' : signal;
+
+  for (const child of children) {
+    if (!child.killed) {
+      child.kill(terminationSignal);
+    }
+  }
+}
+
+for (const command of commands) {
+  const child = spawn(command.cmd, command.args, {
+    env: process.env,
+    shell: process.platform === 'win32',
+    stdio: ['inherit', 'pipe', 'pipe']
+  });
+
+  children.push(child);
+  attachOutput(child.stdout, process.stdout, command.name);
+  attachOutput(child.stderr, process.stderr, command.name);
+
+  child.on('error', (error) => {
+    process.stderr.write(`[${command.name}] ${error.message}\n`);
+    stopChildren();
+    process.exitCode = 1;
+  });
+
+  child.on('exit', (code, signal) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    if (signal) {
+      stopChildren(signal);
+      process.exitCode = 1;
+      return;
+    }
+
+    if (code !== 0) {
+      process.stderr.write(`[${command.name}] exited with code ${code}\n`);
+      stopChildren();
+      process.exit(code ?? 1);
+    } else {
+      stopChildren();
+      process.exit(0);
+    }
+  });
+}
+
+function handleSignal(signal) {
+  if (shuttingDown) {
+    return;
+  }
+
+  stopChildren(signal);
+  process.exit(0);
+}
+
+process.on('SIGINT', () => handleSignal('SIGINT'));
+process.on('SIGTERM', () => handleSignal('SIGTERM'));


### PR DESCRIPTION
## Summary
- install the OpenSSL runtime packages alongside CA certificates in the backend image base layer
- export Prisma engine environment variables so the CLI and client always load the Debian OpenSSL 3 builds that ship with the app
- switch the workspace to npm by updating the root scripts, dropping the pnpm workspace file, and adding a Node-based dev orchestrator
- update the backend and frontend Dockerfiles to install dependencies with npm

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04d85abe083248f79d28c3f22c25c