### PR TITLE
Fix Express request user typing

### DIFF
--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,11 @@
+import type { AuthenticatedUser } from "./auth.js";
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: AuthenticatedUser;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- augment the Express Request type to expose the authenticated user attached by the auth middleware

## Testing
- npm --prefix backend run build *(fails: missing @types/pg and optional bcrypt typings in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e07166694c8324a3afb65af5166eeb