### PR TITLE
Fix demo admin password hash

### DIFF
--- a/backend/src/services/demo-data.ts
+++ b/backend/src/services/demo-data.ts
@@ -124,7 +124,7 @@ const users: DemoUser[] = [
     id: "demo-admin",
     email: "admin@org",
     name: "Admin",
-    password: "$2b$10$vL56KzxMpswj5SP8yNQqAuc80Cgmw0DttQbHW6Fy4M4TwWCeekeIG",
+    password: "$2b$10$/CfVruRtv68zrqAakpRal.yNpNlaajxcS/sFdnG6H5kZvr4W5yS1q",
     role: "ADMIN",
     providerId,
     firstName: "Admin",


### PR DESCRIPTION
## Summary
- update the demo admin user's stored password hash so the documented admin123 credentials work in demo mode

## Testing
- npm run build *(fails: missing TypeScript typings for pg/express request augmentation and bcrypt fallback)*

------
https://chatgpt.com/codex/tasks/task_e_68e089c41f2083249cd0f8c2754f4804