### PR TITLE
Actualizar vistas administrativas con datos reales

### DIFF
--- a/frontend/src/pages/AdminAuditoria.tsx
+++ b/frontend/src/pages/AdminAuditoria.tsx
@@ -1,19 +1,82 @@
-import { Button, Table } from "../components/ui";
+import { useEffect, useMemo, useState } from "react";
+
+import { Button, Card, Table } from "../components/ui";
+import { listarAuditoria, type AuditLogDTO } from "../services/auditoria";
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
 
 export default function AdminAuditoria() {
+  const [logs, setLogs] = useState<AuditLogDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const data = await listarAuditoria();
+        if (!cancelled) {
+          setLogs(data);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setLogs([]);
+          setError("No se pudo cargar el registro de auditoría.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const rows = useMemo(
+    () =>
+      logs.map((log) => [
+        formatDate(log.createdAt),
+        log.user?.email ?? "—",
+        log.action || log.method,
+        log.path,
+        String(log.status),
+        log.ip ?? "—"
+      ]),
+    [logs]
+  );
+
+  const isEmpty = !loading && rows.length === 0;
+
   return (
     <section className="space-y-4">
       <header className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Auditoría</h1>
-        <Button variant="ghost">Exportar CSV</Button>
+        <Button variant="ghost" disabled={rows.length === 0}>
+          Exportar CSV
+        </Button>
       </header>
-      <Table
-        columns={["Fecha", "Usuario", "Acción", "Entidad", "Resultado", "IP"]}
-        rows={[
-          ["2025-09-30 10:10", "admin@org", "POST", "/cursos", "201", "190.54.12.10"],
-          ["2025-09-30 10:12", "instructor@org", "PATCH", "/asistencias/123", "200", "190.54.12.10"],
-        ]}
-      />
+      {loading ? (
+        <Card className="p-4 text-sm text-gray-600">Cargando registros…</Card>
+      ) : error ? (
+        <Card className="p-4 text-sm text-red-600">{error}</Card>
+      ) : rows.length > 0 ? (
+        <Table
+          columns={["Fecha", "Usuario", "Acción", "Entidad", "Resultado", "IP"]}
+          rows={rows}
+        />
+      ) : null}
+      {isEmpty ? (
+        <Card className="p-4 text-sm text-gray-600">No hay registros de auditoría.</Card>
+      ) : null}
       <div className="card flex items-center gap-3 p-4 text-sm text-gray-600">
         Auditoría inmutable. Acceso solo para Administradores.
       </div>

--- a/frontend/src/pages/AdminCursos.tsx
+++ b/frontend/src/pages/AdminCursos.tsx
@@ -146,6 +146,27 @@ export default function AdminCursos() {
     [query, items]
   );
 
+  const totalInstructores = useMemo(() => {
+    const nombres = new Set<string>();
+    items.forEach((curso) => {
+      curso.instructores.forEach((nombre) => {
+        if (nombre) {
+          nombres.add(nombre);
+        }
+      });
+    });
+    return nombres.size;
+  }, [items]);
+
+  const promedioInstructores = useMemo(() => {
+    if (items.length === 0) return 0;
+    const total = items.reduce(
+      (suma, curso) => suma + curso.instructores.length,
+      0
+    );
+    return total / items.length;
+  }, [items]);
+
   const updateFormField = (field: keyof CursoFormState) => (
     event: ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
@@ -442,9 +463,9 @@ export default function AdminCursos() {
             </Card>
             <Card className="p-4">
               <div className="text-sm text-gray-500">Instructores</div>
-              <div className="mt-1 text-2xl font-bold">3</div>
+              <div className="mt-1 text-2xl font-bold">{totalInstructores}</div>
               <div className="mt-2 text-xs text-gray-500">
-                Promedio 1.5 por curso
+                Promedio {items.length ? promedioInstructores.toFixed(1) : "—"} por curso
               </div>
             </Card>
             <Card className="p-4">

--- a/frontend/src/pages/Reporteria.tsx
+++ b/frontend/src/pages/Reporteria.tsx
@@ -49,14 +49,7 @@ export default function Reporteria() {
 
   const tableRows = useMemo(
     () =>
-      rows.length
-        ? rows.map((row) =>
-            columns.map((column) => String(row[column] ?? ""))
-          )
-        : [
-            ["CUR-001", "2025-10-03", "Ana Soto", "P (100%)"],
-            ["CUR-001", "2025-10-10", "Leandro Ruiz", "A (0%)"]
-          ],
+      rows.map((row) => columns.map((column) => String(row[column] ?? ""))),
     [columns, rows]
   );
 
@@ -167,6 +160,9 @@ export default function Reporteria() {
           <Card className="p-4">
             <p className="text-sm font-semibold">Vista previa</p>
             <Table columns={columns} rows={tableRows} />
+            {!rows.length && !loading ? (
+              <p className="mt-3 text-sm text-gray-500">Sin resultados.</p>
+            ) : null}
           </Card>
         </div>
         <div className="col-span-12 space-y-4 lg:col-span-4">

--- a/frontend/src/services/auditoria.ts
+++ b/frontend/src/services/auditoria.ts
@@ -1,0 +1,24 @@
+import api from "./http";
+
+export type AuditLogDTO = {
+  id: string;
+  userId: string | null;
+  action: string;
+  method: string;
+  path: string;
+  status: number;
+  ip: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  user?: {
+    id: string;
+    email: string | null;
+    name: string | null;
+    role: string | null;
+  } | null;
+};
+
+export async function listarAuditoria() {
+  const { data } = await api.get<AuditLogDTO[]>("/auditoria");
+  return data;
+}


### PR DESCRIPTION
## Summary
- consumir la API de auditoría para poblar la tabla con estados de carga y vacío
- calcular las métricas de instructores de cursos usando los datos cargados
- eliminar filas ficticias en reportería y mostrar mensajes cuando no hay resultados

## Testing
- npm run lint *(falla: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e0a346d3f88324a4a4f8a0969d0735