### PR TITLE
Align enrollment import handling with upsert signature

### DIFF
--- a/backend/src/database/enrollments.ts
+++ b/backend/src/database/enrollments.ts
@@ -7,6 +7,11 @@ export interface DbEnrollment {
   createdAt: Date;
 }
 
+export interface UpsertEnrollmentInput {
+  participantId: string;
+  courseId: string;
+}
+
 export async function findEnrollment(participantId: string, courseId: string): Promise<DbEnrollment | null> {
   return queryOne<DbEnrollment>(
     'SELECT "id", "participantId", "courseId", "createdAt" FROM "Enrollment" WHERE "participantId" = $1 AND "courseId" = $2',
@@ -14,10 +19,7 @@ export async function findEnrollment(participantId: string, courseId: string): P
   );
 }
 
-export async function upsertEnrollment(data: {
-  participantId: string;
-  courseId: string;
-}): Promise<DbEnrollment> {
+export async function upsertEnrollment(data: UpsertEnrollmentInput): Promise<DbEnrollment> {
   const inserted = await queryOne<DbEnrollment>(
     'INSERT INTO "Enrollment" ("participantId", "courseId") VALUES ($1,$2) ' +
       'ON CONFLICT ("participantId", "courseId") DO NOTHING RETURNING "id", "participantId", "courseId", "createdAt"',

--- a/backend/src/routes/imports.ts
+++ b/backend/src/routes/imports.ts
@@ -157,13 +157,9 @@ router.post(
 
             if (before) updated += 1;
 
-            const role = typeof row.rol_en_curso === "string" ? row.rol_en_curso.trim() : undefined;
-
             await upsertEnrollment({
               participantId: participant.id,
-              courseId: course.id,
-              role: role || undefined,
-              importJobId: importJob.id
+              courseId: course.id
             });
 
             if (!before) created += 1;


### PR DESCRIPTION
## Summary
- add a shared UpsertEnrollmentInput type for enrollment persistence
- stop passing unsupported enrollment fields during participant imports

## Testing
- npm run build *(fails: repository lacks type declarations for pg, bcrypt, and Express request.user)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a3448bd88324932ca169b8b8da33