### PR TITLE
Align backend database queries with new schema

### DIFF
--- a/backend/src/database/attendance.ts
+++ b/backend/src/database/attendance.ts
@@ -72,15 +72,15 @@ export async function findAttendanceBySession(sessionId: string): Promise<DbAtte
     course_createdAt: Date;
     course_updatedAt: Date;
   }>(
-    'SELECT a."id" AS attendance_id, a."sessionId" AS attendance_sessionId, a."enrollmentId" AS attendance_enrollmentId, a."state" AS attendance_state, a."observation" AS attendance_observation, a."updatedById" AS attendance_updatedById, a."updatedAt" AS attendance_updatedAt, a."createdAt" AS attendance_createdAt, ' +
-      'e."id" AS enrollment_id, e."participantId" AS enrollment_participantId, e."courseId" AS enrollment_courseId, e."createdAt" AS enrollment_createdAt, ' +
-      'p."id" AS participant_id, p."email" AS participant_email, p."name" AS participant_name, p."providerId" AS participant_providerId, p."createdAt" AS participant_createdAt, p."updatedAt" AS participant_updatedAt, ' +
-      'c."id" AS course_id, c."code" AS course_code, c."name" AS course_name, c."startDate" AS course_startDate, c."endDate" AS course_endDate, c."providerId" AS course_providerId, c."createdAt" AS course_createdAt, c."updatedAt" AS course_updatedAt ' +
-      'FROM "Attendance" a ' +
-      'JOIN "Enrollment" e ON e."id" = a."enrollmentId" ' +
-      'JOIN "Participant" p ON p."id" = e."participantId" ' +
-      'JOIN "Course" c ON c."id" = e."courseId" ' +
-      'WHERE a."sessionId" = $1',
+    'SELECT a.id AS attendance_id, a.session_id AS "attendance_sessionId", a.enrollment_id AS "attendance_enrollmentId", a.state AS attendance_state, a.observation AS attendance_observation, a.updated_by_id AS "attendance_updatedById", a.updated_at AS "attendance_updatedAt", a.created_at AS "attendance_createdAt", ' +
+      'e.id AS enrollment_id, e.participant_id AS "enrollment_participantId", e.course_id AS "enrollment_courseId", e.created_at AS "enrollment_createdAt", ' +
+      'p.id AS participant_id, p.email AS participant_email, p.name AS participant_name, p.provider_id AS "participant_providerId", p.created_at AS "participant_createdAt", p.updated_at AS "participant_updatedAt", ' +
+      'c.id AS course_id, c.code AS course_code, c.name AS course_name, c.start_date AS "course_startDate", c.end_date AS "course_endDate", c.provider_id AS "course_providerId", c.created_at AS "course_createdAt", c.updated_at AS "course_updatedAt" ' +
+      'FROM attendance a ' +
+      'JOIN enrollment e ON e.id = a.enrollment_id ' +
+      'JOIN participant p ON p.id = e.participant_id ' +
+      'JOIN course c ON c.id = e.course_id ' +
+      'WHERE a.session_id = $1',
     [sessionId]
   );
 
@@ -133,8 +133,8 @@ export async function upsertAttendance(
   client?: DatabaseClient
 ): Promise<DbAttendance> {
   const update = await queryOne<DbAttendance>(
-    'UPDATE "Attendance" SET "state" = $3, "observation" = $4, "updatedById" = $5, "updatedAt" = CURRENT_TIMESTAMP ' +
-      'WHERE "sessionId" = $1 AND "enrollmentId" = $2 RETURNING *',
+    'UPDATE attendance SET state = $3, observation = $4, updated_by_id = $5, updated_at = CURRENT_TIMESTAMP ' +
+      'WHERE session_id = $1 AND enrollment_id = $2 RETURNING id, session_id AS "sessionId", enrollment_id AS "enrollmentId", state, observation, updated_by_id AS "updatedById", updated_at AS "updatedAt", created_at AS "createdAt"',
     [
       data.sessionId,
       data.enrollmentId,
@@ -148,7 +148,7 @@ export async function upsertAttendance(
   if (update) return update;
 
   const insert = await queryOne<DbAttendance>(
-    'INSERT INTO "Attendance" ("sessionId", "enrollmentId", "state", "observation", "updatedById") VALUES ($1, $2, $3, $4, $5) RETURNING *',
+    'INSERT INTO attendance (session_id, enrollment_id, state, observation, updated_by_id) VALUES ($1, $2, $3, $4, $5) RETURNING id, session_id AS "sessionId", enrollment_id AS "enrollmentId", state, observation, updated_by_id AS "updatedById", updated_at AS "updatedAt", created_at AS "createdAt"',
     [
       data.sessionId,
       data.enrollmentId,

--- a/backend/src/database/audit.ts
+++ b/backend/src/database/audit.ts
@@ -28,7 +28,7 @@ export async function insertAuditLog(data: {
   metadata?: Record<string, unknown> | null;
 }): Promise<void> {
   await query(
-    'INSERT INTO "AuditLog" ("userId", "action", "method", "path", "status", "ip", "metadata") VALUES ($1,$2,$3,$4,$5,$6,$7)',
+    'INSERT INTO audit_log (user_id, action, method, path, status, ip, metadata) VALUES ($1,$2,$3,$4,$5,$6,$7)',
     [
       data.userId ?? null,
       data.action,
@@ -57,8 +57,8 @@ export async function listAuditLogs(limit = 200): Promise<AuditLogRow[]> {
     user_name: string | null;
     user_role: string | null;
   }>(
-    'SELECT a."id", a."userId", a."action", a."method", a."path", a."status", a."ip", a."metadata", a."createdAt", u."id" AS user_id, u."email" AS user_email, u."name" AS user_name, u."role" AS user_role ' +
-      'FROM "AuditLog" a LEFT JOIN "User" u ON u."id" = a."userId" ORDER BY a."createdAt" DESC LIMIT $1',
+    'SELECT a.id, a.user_id AS "userId", a.action, a.method, a.path, a.status, a.ip, a.metadata, a.created_at AS "createdAt", u.id AS user_id, u.email AS user_email, u.name AS user_name, u.role AS user_role ' +
+      'FROM audit_log a LEFT JOIN app_user u ON u.id = a.user_id ORDER BY a.created_at DESC LIMIT $1',
     [limit]
   );
 

--- a/backend/src/database/documents.ts
+++ b/backend/src/database/documents.ts
@@ -26,7 +26,7 @@ export async function createDocument(data: {
   createdById: string;
 }): Promise<DbDocument> {
   const row = await queryOne<DbDocument>(
-    'INSERT INTO "Document" ("filename", "originalName", "mimeType", "size", "checksum", "metadata", "createdById") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *',
+    'INSERT INTO document (filename, original_name, mime_type, size, checksum, metadata, created_by_id) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING id, filename, original_name AS "originalName", mime_type AS "mimeType", size, checksum, url, metadata, created_by_id AS "createdById", provider_id AS "providerId", course_id AS "courseId", created_at AS "createdAt", updated_at AS "updatedAt"',
     [
       data.filename,
       data.originalName,
@@ -47,18 +47,18 @@ export async function updateDocument(id: string, data: { providerId?: string | n
   const values: unknown[] = [id];
 
   if (Object.prototype.hasOwnProperty.call(data, "providerId")) {
-    setStatements.push(`"providerId" = $${values.length + 1}`);
+    setStatements.push(`provider_id = $${values.length + 1}`);
     values.push(data.providerId ?? null);
   }
 
   if (Object.prototype.hasOwnProperty.call(data, "courseId")) {
-    setStatements.push(`"courseId" = $${values.length + 1}`);
+    setStatements.push(`course_id = $${values.length + 1}`);
     values.push(data.courseId ?? null);
   }
 
   if (setStatements.length === 0) return;
 
-  setStatements.push(`"updatedAt" = CURRENT_TIMESTAMP`);
-  const sql = `UPDATE "Document" SET ${setStatements.join(", ")} WHERE "id" = $1`;
+  setStatements.push(`updated_at = CURRENT_TIMESTAMP`);
+  const sql = `UPDATE document SET ${setStatements.join(", ")} WHERE id = $1`;
   await query(sql, values);
 }

--- a/backend/src/database/enrollments.ts
+++ b/backend/src/database/enrollments.ts
@@ -9,7 +9,7 @@ export interface DbEnrollment {
 
 export async function findEnrollment(participantId: string, courseId: string): Promise<DbEnrollment | null> {
   return queryOne<DbEnrollment>(
-    'SELECT "id", "participantId", "courseId", "createdAt" FROM "Enrollment" WHERE "participantId" = $1 AND "courseId" = $2',
+    'SELECT id, participant_id AS "participantId", course_id AS "courseId", created_at AS "createdAt" FROM enrollment WHERE participant_id = $1 AND course_id = $2',
     [participantId, courseId]
   );
 }
@@ -19,8 +19,8 @@ export async function upsertEnrollment(data: {
   courseId: string;
 }): Promise<DbEnrollment> {
   const inserted = await queryOne<DbEnrollment>(
-    'INSERT INTO "Enrollment" ("participantId", "courseId") VALUES ($1,$2) ' +
-      'ON CONFLICT ("participantId", "courseId") DO NOTHING RETURNING "id", "participantId", "courseId", "createdAt"',
+    'INSERT INTO enrollment (participant_id, course_id) VALUES ($1,$2) ' +
+      'ON CONFLICT (participant_id, course_id) DO NOTHING RETURNING id, participant_id AS "participantId", course_id AS "courseId", created_at AS "createdAt"',
     [data.participantId, data.courseId]
   );
 

--- a/backend/src/database/grades.ts
+++ b/backend/src/database/grades.ts
@@ -48,13 +48,13 @@ export async function listGradesByCourse(courseId: string): Promise<GradeWithRel
     participant_createdAt: Date;
     participant_updatedAt: Date;
   }>(
-    'SELECT g."id" AS grade_id, g."enrollmentId" AS grade_enrollmentId, g."type" AS grade_type, g."score" AS grade_score, g."date" AS grade_date, g."createdAt" AS grade_createdAt, g."updatedAt" AS grade_updatedAt, ' +
-      'e."id" AS enrollment_id, e."participantId" AS enrollment_participantId, e."courseId" AS enrollment_courseId, e."createdAt" AS enrollment_createdAt, ' +
-      'p."id" AS participant_id, p."email" AS participant_email, p."name" AS participant_name, p."providerId" AS participant_providerId, p."createdAt" AS participant_createdAt, p."updatedAt" AS participant_updatedAt ' +
-      'FROM "Grade" g ' +
-      'JOIN "Enrollment" e ON e."id" = g."enrollmentId" ' +
-      'JOIN "Participant" p ON p."id" = e."participantId" ' +
-      'WHERE e."courseId" = $1',
+    'SELECT g.id AS grade_id, g.enrollment_id AS "grade_enrollmentId", g.type AS grade_type, g.score AS grade_score, g.date AS grade_date, g.created_at AS "grade_createdAt", g.updated_at AS "grade_updatedAt", ' +
+      'e.id AS enrollment_id, e.participant_id AS "enrollment_participantId", e.course_id AS "enrollment_courseId", e.created_at AS "enrollment_createdAt", ' +
+      'p.id AS participant_id, p.email AS participant_email, p.name AS participant_name, p.provider_id AS "participant_providerId", p.created_at AS "participant_createdAt", p.updated_at AS "participant_updatedAt" ' +
+      'FROM grade g ' +
+      'JOIN enrollment e ON e.id = g.enrollment_id ' +
+      'JOIN participant p ON p.id = e.participant_id ' +
+      'WHERE e.course_id = $1',
     [courseId]
   );
 
@@ -92,7 +92,7 @@ export interface CreateGradeInput {
 
 export async function createGrade(input: CreateGradeInput): Promise<DbGrade> {
   const row = await queryOne<DbGrade>(
-    'INSERT INTO "Grade" ("enrollmentId", "type", "score", "date") VALUES ($1,$2,$3,$4) RETURNING *',
+    'INSERT INTO grade (enrollment_id, type, score, date) VALUES ($1,$2,$3,$4) RETURNING id, enrollment_id AS "enrollmentId", type, score, date, created_at AS "createdAt", updated_at AS "updatedAt"',
     [input.enrollmentId, input.type, input.score, input.date ?? new Date()]
   );
 

--- a/backend/src/database/import-jobs.ts
+++ b/backend/src/database/import-jobs.ts
@@ -29,7 +29,7 @@ export async function createImportJob(data: {
   startedAt?: Date | null;
 }): Promise<DbImportJob> {
   const row = await queryOne<DbImportJob>(
-    'INSERT INTO "ImportJob" ("kind", "status", "documentId", "createdById", "totalRows", "startedAt") VALUES ($1,$2,$3,$4,$5,$6) RETURNING *',
+    'INSERT INTO import_job (kind, status, document_id, created_by_id, total_rows, started_at) VALUES ($1,$2,$3,$4,$5,$6) RETURNING id, status, kind, provider_id AS "providerId", course_id AS "courseId", document_id AS "documentId", created_by_id AS "createdById", total_rows AS "totalRows", processed_rows AS "processedRows", success_count AS "successCount", failure_count AS "failureCount", error_message AS "errorMessage", started_at AS "startedAt", completed_at AS "completedAt", created_at AS "createdAt", updated_at AS "updatedAt"',
     [
       data.kind,
       data.status,
@@ -54,44 +54,44 @@ export async function updateImportJob(id: string, data: Partial<{
   errorMessage: string | null;
   completedAt: Date | null;
 }>): Promise<void> {
-  const setStatements: string[] = ['"updatedAt" = CURRENT_TIMESTAMP'];
+  const setStatements: string[] = ['updated_at = CURRENT_TIMESTAMP'];
   const values: unknown[] = [id];
 
   if (data.status !== undefined) {
-    setStatements.push(`"status" = $${values.length + 1}`);
+    setStatements.push(`status = $${values.length + 1}`);
     values.push(data.status);
   }
   if (data.providerId !== undefined) {
-    setStatements.push(`"providerId" = $${values.length + 1}`);
+    setStatements.push(`provider_id = $${values.length + 1}`);
     values.push(data.providerId);
   }
   if (data.courseId !== undefined) {
-    setStatements.push(`"courseId" = $${values.length + 1}`);
+    setStatements.push(`course_id = $${values.length + 1}`);
     values.push(data.courseId);
   }
   if (data.processedRows !== undefined) {
-    setStatements.push(`"processedRows" = $${values.length + 1}`);
+    setStatements.push(`processed_rows = $${values.length + 1}`);
     values.push(data.processedRows);
   }
   if (data.successCount !== undefined) {
-    setStatements.push(`"successCount" = $${values.length + 1}`);
+    setStatements.push(`success_count = $${values.length + 1}`);
     values.push(data.successCount);
   }
   if (data.failureCount !== undefined) {
-    setStatements.push(`"failureCount" = $${values.length + 1}`);
+    setStatements.push(`failure_count = $${values.length + 1}`);
     values.push(data.failureCount);
   }
   if (data.errorMessage !== undefined) {
-    setStatements.push(`"errorMessage" = $${values.length + 1}`);
+    setStatements.push(`error_message = $${values.length + 1}`);
     values.push(data.errorMessage);
   }
   if (data.completedAt !== undefined) {
-    setStatements.push(`"completedAt" = $${values.length + 1}`);
+    setStatements.push(`completed_at = $${values.length + 1}`);
     values.push(data.completedAt);
   }
 
   if (setStatements.length === 1) return;
 
-  const sql = `UPDATE "ImportJob" SET ${setStatements.join(", ")} WHERE "id" = $1`;
+  const sql = `UPDATE import_job SET ${setStatements.join(", ")} WHERE id = $1`;
   await query(sql, values);
 }

--- a/backend/src/database/participants.ts
+++ b/backend/src/database/participants.ts
@@ -15,8 +15,8 @@ export async function upsertParticipantByEmail(data: {
   providerId?: string | null;
 }): Promise<DbParticipant> {
   const row = await queryOne<DbParticipant>(
-    'INSERT INTO "Participant" ("email", "name", "providerId") VALUES ($1,$2,$3) ' +
-      'ON CONFLICT ("email") DO UPDATE SET "name" = EXCLUDED."name", "providerId" = EXCLUDED."providerId", "updatedAt" = CURRENT_TIMESTAMP RETURNING *',
+    'INSERT INTO participant (email, name, provider_id) VALUES ($1,$2,$3) ' +
+      'ON CONFLICT (email) DO UPDATE SET name = EXCLUDED.name, provider_id = EXCLUDED.provider_id, updated_at = CURRENT_TIMESTAMP RETURNING id, email, name, provider_id AS "providerId", created_at AS "createdAt", updated_at AS "updatedAt"',
     [data.email, data.name, data.providerId ?? null]
   );
 

--- a/backend/src/database/providers.ts
+++ b/backend/src/database/providers.ts
@@ -8,12 +8,14 @@ export interface DbProvider {
 }
 
 export async function listProviders(): Promise<DbProvider[]> {
-  return query<DbProvider>('SELECT "id", "name", "createdAt", "updatedAt" FROM "Provider" ORDER BY "name" ASC');
+  return query<DbProvider>(
+    'SELECT id, name, created_at AS "createdAt", updated_at AS "updatedAt" FROM provider ORDER BY name ASC'
+  );
 }
 
 export async function createProvider(data: { name: string }): Promise<DbProvider> {
   const row = await queryOne<DbProvider>(
-    'INSERT INTO "Provider" ("name") VALUES ($1) RETURNING "id", "name", "createdAt", "updatedAt"',
+    'INSERT INTO provider (name) VALUES ($1) RETURNING id, name, created_at AS "createdAt", updated_at AS "updatedAt"',
     [data.name]
   );
 
@@ -23,7 +25,7 @@ export async function createProvider(data: { name: string }): Promise<DbProvider
 
 export async function upsertProviderByName(name: string): Promise<DbProvider> {
   const row = await queryOne<DbProvider>(
-    'INSERT INTO "Provider" ("name") VALUES ($1) ON CONFLICT ("name") DO UPDATE SET "updatedAt" = CURRENT_TIMESTAMP RETURNING "id", "name", "createdAt", "updatedAt"',
+    'INSERT INTO provider (name) VALUES ($1) ON CONFLICT (name) DO UPDATE SET updated_at = CURRENT_TIMESTAMP RETURNING id, name, created_at AS "createdAt", updated_at AS "updatedAt"',
     [name]
   );
   if (!row) throw new Error("Failed to upsert provider");

--- a/backend/src/database/sessions.ts
+++ b/backend/src/database/sessions.ts
@@ -35,10 +35,10 @@ export async function listSessionsForInstructor(userId: string): Promise<Session
     course_createdAt: Date;
     course_updatedAt: Date;
   }>(
-    'SELECT s."id" AS session_id, s."courseId" AS session_courseId, s."date" AS session_date, s."createdAt" AS session_createdAt, ' +
-      'c."id" AS course_id, c."code" AS course_code, c."name" AS course_name, c."startDate" AS course_startDate, c."endDate" AS course_endDate, c."providerId" AS course_providerId, c."createdAt" AS course_createdAt, c."updatedAt" AS course_updatedAt ' +
-      'FROM "Session" s JOIN "Course" c ON c."id" = s."courseId" ' +
-      'WHERE EXISTS (SELECT 1 FROM "CourseInstructor" ci WHERE ci."courseId" = c."id" AND ci."userId" = $1)',
+    'SELECT s.id AS session_id, s.course_id AS "session_courseId", s.date AS session_date, s.created_at AS "session_createdAt", ' +
+      'c.id AS course_id, c.code AS course_code, c.name AS course_name, c.start_date AS "course_startDate", c.end_date AS "course_endDate", c.provider_id AS "course_providerId", c.created_at AS "course_createdAt", c.updated_at AS "course_updatedAt" ' +
+      'FROM session s JOIN course c ON c.id = s.course_id ' +
+      'WHERE EXISTS (SELECT 1 FROM course_instructor ci WHERE ci.course_id = c.id AND ci.user_id = $1)',
     [userId]
   );
 
@@ -62,7 +62,7 @@ export async function listSessionsForInstructor(userId: string): Promise<Session
 
 export async function createSession(data: { courseId: string; date: Date }): Promise<DbSession> {
   const row = await queryOne<DbSession>(
-    'INSERT INTO "Session" ("courseId", "date") VALUES ($1, $2) RETURNING *',
+    'INSERT INTO session (course_id, date) VALUES ($1, $2) RETURNING id, course_id AS "courseId", date, created_at AS "createdAt"',
     [data.courseId, data.date]
   );
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -26,11 +26,13 @@ export function auth(required = true) {
     try {
       const payload = jwt.verify(token, env.JWT_SECRET) as TokenPayload | string;
       if (typeof payload === "string") {
+        if (!required) return next();
         return res.status(401).json({ error: "Invalid token" });
       }
 
       const { sub, role, providerId = null } = payload;
       if (!sub || !role) {
+        if (!required) return next();
         return res.status(401).json({ error: "Invalid token" });
       }
 
@@ -38,6 +40,7 @@ export function auth(required = true) {
       attachUser(req, user);
       next();
     } catch {
+      if (!required) return next();
       return res.status(401).json({ error: "Invalid token" });
     }
   };


### PR DESCRIPTION
## Summary
- update backend database query modules to use the snake_case tables and columns defined in the new schema
- alias query results so existing TypeScript interfaces continue to receive camelCase fields
- adjust dynamic update helpers to reference the new column names when persisting changes
- allow optional authentication middleware to ignore expired/invalid tokens so refresh requests can proceed

## Testing
- npm run build:backend *(fails: existing TypeScript errors regarding missing module declarations and Express request typings)*

------
https://chatgpt.com/codex/tasks/task_e_68e1147cfe14832488c0581657d14cb8